### PR TITLE
fix: WhoAreYou change detection

### DIFF
--- a/src/components/commons/SurveyPage/SurveyPageStep/SurveyPageStep.tsx
+++ b/src/components/commons/SurveyPage/SurveyPageStep/SurveyPageStep.tsx
@@ -7,7 +7,7 @@ import { FORMAT_TIME, MINUTE_LABEL, START_TIME_DAY } from "../../../../constants
 import { EdtRoutesNameEnum } from "../../../../enumerations/EdtRoutesNameEnum";
 import { OrchestratorContext } from "../../../../interface/lunatic/Lunatic";
 import { OrchestratorForStories, callbackHolder } from "../../../../orchestrator/Orchestrator";
-import { SetStateAction, useCallback, useEffect, useState } from "react";
+import { SetStateAction, useCallback, useEffect, useMemo, useState } from "react";
 import { isAndroid, isIOS } from "react-device-detect";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useOutletContext } from "react-router";
@@ -40,6 +40,7 @@ export interface SurveyPageStepProps {
     disableButton?: boolean;
     validateButton?: () => void;
     withBottomPadding?: boolean;
+    lunaticComponents?: Record<string, any>;
 }
 
 const SurveyPageStep = (props: SurveyPageStepProps) => {
@@ -83,21 +84,24 @@ const SurveyPageStep = (props: SurveyPageStepProps) => {
 
     const [isModalDisplayed, setIsModalDisplayed] = useState<boolean>(false);
 
-    const componentLunaticProps: any = {
-        onSelectValue: () => validateAndNextStep(idSurvey, context.source, currentPage),
-        options: specifiquesProps?.options,
-        defaultIcon: specifiquesProps?.defaultIcon,
-        icon: specifiquesProps?.icon,
-        language: getLanguage(),
-        constants: {
-            START_TIME_DAY: START_TIME_DAY,
-            FORMAT_TIME: FORMAT_TIME,
-            MINUTE_LABEL: MINUTE_LABEL,
-        },
-        extensionIcon: <ExtensionIcon aria-label={t("accessibility.asset.mui-icon.extension")} />,
-        modifiable: modifiable,
-        defaultLanguage: "fr",
-    };
+    const componentLunaticProps: any = useMemo(
+        () => ({
+            onSelectValue: () => validateAndNextStep(idSurvey, context.source, currentPage),
+            options: specifiquesProps?.options,
+            defaultIcon: specifiquesProps?.defaultIcon,
+            icon: specifiquesProps?.icon,
+            language: getLanguage(),
+            constants: {
+                START_TIME_DAY: START_TIME_DAY,
+                FORMAT_TIME: FORMAT_TIME,
+                MINUTE_LABEL: MINUTE_LABEL,
+            },
+            extensionIcon: <ExtensionIcon aria-label={t("accessibility.asset.mui-icon.extension")} />,
+            modifiable: modifiable,
+            defaultLanguage: "fr",
+        }),
+        [specifiquesProps, modifiable],
+    );
 
     const IconError = errorIcon as React.FunctionComponent<React.SVGProps<SVGSVGElement>>;
 
@@ -157,16 +161,6 @@ const SurveyPageStep = (props: SurveyPageStepProps) => {
         modifiable: modifiable,
     };
 
-    const orchestratorProps = {
-        source: context.source,
-        data: getData(idSurvey), //context.data,
-        cbHolder: callbackHolder,
-        page: getOrchestratorPage(currentPage, context.surveyRootPage),
-        overrideOptions: specifiquesProps?.referentiel,
-        componentSpecificProps: componentLunaticProps,
-        idSurvey: idSurvey,
-    };
-
     const validateAndNav = (
         forceQuit: boolean,
         setIsModalDisplayed: (value: SetStateAction<boolean>) => void,
@@ -178,6 +172,7 @@ const SurveyPageStep = (props: SurveyPageStepProps) => {
         }
     };
     const surveyPageProps = isStep ? surveyPageStepProps : surveyPageNotStepProps;
+    const surveyData = useMemo(() => getData(idSurvey), [idSurvey]);
 
     return (
         <Box
@@ -195,7 +190,15 @@ const SurveyPageStep = (props: SurveyPageStepProps) => {
                         )}
                         content={t("component.modal-edt.modal-felicitation.activity-content")}
                     />
-                    <OrchestratorForStories {...orchestratorProps} />
+                    <OrchestratorForStories
+                        source={context.source}
+                        data={surveyData}
+                        cbHolder={callbackHolder}
+                        page={getOrchestratorPage(currentPage, context.surveyRootPage)}
+                        overrideOptions={specifiquesProps?.referentiel}
+                        componentSpecificProps={componentLunaticProps}
+                        components={props.lunaticComponents}
+                    />
                 </FlexCenter>
             </SurveyPage>
         </Box>

--- a/src/orchestrator/Orchestrator.tsx
+++ b/src/orchestrator/Orchestrator.tsx
@@ -36,6 +36,8 @@ export type OrchestratorProps = {
     iteration?: number;
     componentSpecificProps?: any;
     overrideOptions?: any;
+    // Replace lunatic components
+    components?: Record<string, any>;
 };
 
 const renderLoading = () => {
@@ -350,7 +352,7 @@ export const OrchestratorForStories = (props: OrchestratorProps) => {
                 >
                     {components.map(function (component: any) {
                         const { id, componentType, response, options, value, ...other } = component;
-                        const Component = (lunatic as any)[componentType];
+                        const Component = (props.components ?? lunatic)[componentType];
                         return (
                             <div className="lunatic lunatic-component" key={`component-${id}`}>
                                 <Component

--- a/src/pages/who-are-you/WhoAreYou.tsx
+++ b/src/pages/who-are-you/WhoAreYou.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React, { useCallback, useEffect, useMemo } from "react";
 import WhoAreYouImg from "../../assets/illustration/who-are-you.svg?react";
 import SurveyPageStep from "../../components/commons/SurveyPage/SurveyPageStep/SurveyPageStep";
 import { EdtRoutesNameEnum } from "../../enumerations/EdtRoutesNameEnum";
@@ -7,6 +7,10 @@ import { useLocation, useNavigate, useOutletContext } from "react-router-dom";
 import { surveyReadOnly } from "../../service/survey-activity-service";
 import { validateAllGroup } from "../../service/survey-service";
 import { getSurveyIdFromUrl } from "../../utils/utils";
+import * as lunaticComponents from "@inseefr/lunatic/lib/index";
+
+// We will inject a custom handleChange on component to intercept value change
+const originalComponents = lunaticComponents as Record<string, any>;
 
 const WhoAreYouPage = () => {
     const context: OrchestratorContext = useOutletContext();
@@ -20,36 +24,29 @@ const WhoAreYouPage = () => {
     const idSurvey = getSurveyIdFromUrl(context, location);
     const navigate = useNavigate();
 
-    // const keydownChange = useCallback(() => {
-    //     const input = (document.getElementsByClassName("MuiInputBase-input")?.[0] as HTMLInputElement)?.value;
-    //     if (input) {
-    //         setDisabledButton(input.length <= 1);
-    //     }
-    // }, []);
-
-    // React.useEffect(() => {
-    //     document.addEventListener("keyup", keydownChange, true);
-    //     return () => document.removeEventListener("keyup", keydownChange, true);
-    // }, [keydownChange]);
-
-    const keypressChange = useCallback((event: KeyboardEvent) => {
-        const isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
-        if (event.key === "Enter" && isMobile) {
-            (document.activeElement as HTMLElement)?.blur();
-        }
-        const input = (document.getElementsByClassName("MuiInputBase-input")?.[0] as HTMLInputElement)?.value;
-        setDisabledButton(!input || input.length <= 1);
-    }, []);
-
-    React.useEffect(() => {
-        document.addEventListener("keypress", keypressChange, true);
-        return () => document.removeEventListener("keypress", keypressChange, true);
-    }, [keypressChange]);
-
     const validate = useCallback(() => {
-        const input = (document.getElementsByClassName("MuiInputBase-input")?.[0] as HTMLInputElement)?.value;
+        const input = (document.getElementsByClassName("MuiInputBase-input")?.[0] as HTMLInputElement)
+            ?.value;
         validateAllGroup(navigate, idSurvey, input);
     }, [navigate, idSurvey]);
+
+    // Create a list of lunatic components with a spy on handleChange to detect an input
+    const components = useMemo(
+        () => ({
+            ...lunaticComponents,
+            Input: (props: any) => {
+                const handleChange = useCallback(
+                    (response: unknown, value: string, ...rest: any) => {
+                        setDisabledButton(value.length <= 1);
+                        props.handleChange(response, value, ...rest);
+                    },
+                    [props.handleChange, setDisabledButton],
+                );
+                return <originalComponents.Input {...props} handleChange={handleChange} />;
+            },
+        }),
+        [setDisabledButton],
+    );
 
     return (
         <SurveyPageStep
@@ -59,9 +56,9 @@ const WhoAreYouPage = () => {
             isStep={false}
             disableButton={modifiable ? disabledButton : true}
             validateButton={validate}
+            lunaticComponents={components}
         />
     );
-
 };
 
 export default WhoAreYouPage;


### PR DESCRIPTION
Pour lutter contre le problème de bouton désactivé sur la page "WhoAreYou" j'ai changé le système de détection d'input en me branchant directement sur le handleChange de lunatic (plus stable).

Aussi, j'ai mémoisé les données envoyées à l'Orchestrateur, sans cette mémoisation, un rerendu entraine une réinitialisation des données de l'orchestrateur.

1. Un rerendu arrive
2. `getData(idSurvey)` est relancé et renvoie un nouvel objet
3. `useLunatic()` détecte que les data ont changée et réinitialise son état
4. On perd les données entrées

## Alternative

Je ne sais pas si la version de `useLunatic`  utilisé accepte une option pour capturer les changements, méthode qui serait plus pratique que de modifier la liste des composantS.

