### PR TITLE
fix: prevent put request if no activity

### DIFF
--- a/src/service/api-service/putRemoteData.ts
+++ b/src/service/api-service/putRemoteData.ts
@@ -23,6 +23,13 @@ export const requestPutSurveyData = (
     delete tempData.data.COLLECTED?.WEEKLYPLANNER;
     delete tempData.data.stateData;
 
+    // To prevent data from being lost, do not submit data if activity is empty
+    const endTime = tempData.data?.COLLECTED?.END_TIME?.COLLECTED;
+    if (!Array.isArray(endTime) || endTime.length === 0) {
+        console.log("Skip submitting data");
+        return Promise.resolve(data);
+    }
+
     const putLunaticData = axios.put(
         `${stromaeBackOfficeApiBaseUrl}api/survey-unit/${idSurvey}/data`,
         tempData.data,


### PR DESCRIPTION
To prevent lost data, before looking for a deeper cause I remove PUT request with no activities