### PR TITLE
fix: clean callbackholder when orchestrator is unmounted

### DIFF
--- a/src/orchestrator/Orchestrator.tsx
+++ b/src/orchestrator/Orchestrator.tsx
@@ -5,7 +5,7 @@ import { Box, CircularProgress } from "@mui/material";
 import FlexCenter from "../components/commons/FlexCenter/FlexCenter";
 import { FieldNameEnum, FieldNameEnumActivity } from "../enumerations/FieldNameEnum";
 import { LunaticData, LunaticModel } from "../interface/lunatic/Lunatic";
-import React from "react";
+import React, { useEffect } from "react";
 import { getCurrentPageSource } from "../service/orchestrator-service";
 import { isReviewer } from "../service/user-service";
 
@@ -394,6 +394,14 @@ export const OrchestratorForStories = (props: OrchestratorProps) => {
             </Box>
         );
     };
+
+    // Empty callbackHolder when component is unmounted
+    useEffect(() => {
+        return () => {
+            callbackHolder.getData = () => ({});
+            callbackHolder.getErrors = () => ({});
+        };
+    }, []);
 
     return source && data ? renderComponent() : renderLoading();
 };

--- a/src/pages/activity/activity-or-route-planner/ActivityOrRoutePlanner.tsx
+++ b/src/pages/activity/activity-or-route-planner/ActivityOrRoutePlanner.tsx
@@ -129,10 +129,10 @@ const setAlertSnackbar = (
     if (haveOverlaps) {
         setSnackbarText(
             t("page.activity-planner.start-alert") +
-            overlaps
-                .map(o => o?.prev?.concat(t("page.activity-planner.and"), o?.current ?? ""))
-                .join(", ") +
-            t("page.activity-planner.end-alert"),
+                overlaps
+                    .map(o => o?.prev?.concat(t("page.activity-planner.and"), o?.current ?? ""))
+                    .join(", ") +
+                t("page.activity-planner.end-alert"),
         );
         if (!skip) setOpenSnackbar(true);
     } else {
@@ -617,9 +617,10 @@ const ActivityOrRoutePlannerPage = () => {
     );
 
     const closeActivity = useCallback(
-        (closed: boolean, surveyId: string) => () =>
-            onFinish(closed, surveyId, setIsAlertDisplayed, callbackHolder, navigate, context, source),
-        [],
+        (closed: boolean, surveyId: string) => () => {
+            onFinish(closed, surveyId, setIsAlertDisplayed, callbackHolder, navigate, context, source);
+        },
+        [callbackHolder, source, context, setIsAlertDisplayed],
     );
 
     const displayAlert = useCallback(
@@ -716,7 +717,6 @@ const ActivityOrRoutePlannerPage = () => {
                                                 (isReviewerMode() ? (
                                                     <Box className={classes.headerActivityLockBox}>
                                                         <Alert
-
                                                             isAlertDisplayed={isAlertLockDisplayed}
                                                             onCompleteCallBack={lock}
                                                             onCancelCallBack={displayAlert(


### PR DESCRIPTION
## Issue

In some edge cases data from a previous orchestrator was picked up and data were overwritten. [Trello issue](https://trello.com/c/yQfJMDyC)

## Solution

Reset `callbackHolder` global variable when Orchestrator is unmounted to prevent `getData()` persistence after the end of life of the component.  