### PR TITLE
Aauth disconnect

### DIFF
--- a/src/service/auth-service.ts
+++ b/src/service/auth-service.ts
@@ -70,10 +70,20 @@ const createUserManager = () => {
         }
     });
 
+    window.addEventListener("online", () => {
+        userManager.startSilentRenew();
+    });
+    window.addEventListener("offline", () => {
+        userManager.stopSilentRenew();
+    });
+
     return userManager;
 };
 
 const signinSilent = (userManager: UserManager) => {
+    if (!navigator.onLine) {
+        return;
+    }
     userManager
         .signinSilent()
         .then(user => {


### PR DESCRIPTION
Since a userManager cannot be destroyed during the lifecycle of the application. We will try to stop silentRenewal to avoid being redirected to auth portal when offline.