### PR TITLE
fix: suggester option not registered when editing activity

### DIFF
--- a/src/pages/activity/activity-or-route-planner/activity/main-activity/MainActivity.tsx
+++ b/src/pages/activity/activity-or-route-planner/activity/main-activity/MainActivity.tsx
@@ -160,6 +160,12 @@ const MainActivityPage = () => {
                 setValue(
                     idSurvey,
                     FieldNameEnum.MAINACTIVITY_SUGGESTERID,
+                    localStorage.getItem("selectedSuggesterIdNewActivity"),
+                    currentIteration,
+                );
+                setValue(
+                    idSurvey,
+                    FieldNameEnum.MAINACTIVITY_ID,
                     localStorage.getItem("selectedIdNewActivity"),
                     currentIteration,
                 );

--- a/src/service/referentiel-service.ts
+++ b/src/service/referentiel-service.ts
@@ -187,7 +187,7 @@ export const updateReferentielAutoComplete = (
     return saveReferentiels(currentData).then(() => {
         addToAutocompleteActivityReferentiel(newItem).then(referentielData => {
             const newAutocompleteRef = referentielData[ReferentielsEnum.ACTIVITYAUTOCOMPLETE];
-            localStorage.setItem("selectedIdNewActivity", newActivity);
+            localStorage.setItem("selectedSuggesterIdNewActivity", newActivity);
             updateIndexAutoComplete(newAutocompleteRef, index, setIndex);
         });
     });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -36,4 +36,15 @@ export default defineConfig({
             },
         },
     },
+    resolve: {
+        dedupe: [
+            "@mui/material",
+            "@mui/styles",
+            "@mui/utils",
+            "@emotion/react",
+            "react",
+            "react-dom",
+            "@inseefr/lunatic",
+        ],
+    },
 });


### PR DESCRIPTION
Je pense qu'on peut faire plus propre en enlevant ces appels à setValue et au locasStorage et en laissant le "onChange" dans `activityUtils.ts` de lunatic-edt faire la mise à jour de l'activité.

Mais comme j'ai réussi à faire fonctionner le tout, c'est peut-être moins prioritaire