### PR TITLE
fix: work times were emptied out before being sent sometimes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "edt",
-    "version": "4.4.4",
-    "dateVersion": "30/04/2025",
+    "version": "4.4.5",
+    "dateVersion": "16/05/2025",
     "licence": "MIT",
     "type": "module",
     "dependencies": {

--- a/src/pages/end-survey/EndSurvey.tsx
+++ b/src/pages/end-survey/EndSurvey.tsx
@@ -12,7 +12,7 @@ import { FieldNameEnum } from "../../enumerations/FieldNameEnum";
 import { LocalStorageVariableEnum } from "../../enumerations/LocalStorageVariableEnum";
 import { StateDataStateEnum } from "../../enumerations/StateDataStateEnum";
 import { StateData, SurveyData } from "../../interface/entity/Api";
-import { OrchestratorContext } from "../../interface/lunatic/Lunatic";
+import { LunaticData, OrchestratorContext } from "../../interface/lunatic/Lunatic";
 import { callbackHolder } from "../../orchestrator/Orchestrator";
 import { SetStateAction, useCallback, useEffect, useState } from "react";
 import { isMobile } from "react-device-detect";
@@ -39,6 +39,13 @@ import { getSurveyIdFromUrl } from "../../utils/utils";
 const isActivity = () => {
     return getCurrentSurveyRootPage() === EdtRoutesNameEnum.ACTIVITY;
 };
+
+const isWorkEmpty = (collectedWorkTimeSurvey: LunaticData["COLLECTED"]) =>
+    !collectedWorkTimeSurvey?.WORK?.COLLECTED ||
+    !Array.isArray(collectedWorkTimeSurvey.WORK.COLLECTED) ||
+    !collectedWorkTimeSurvey.WORK.COLLECTED.length ||
+    (collectedWorkTimeSurvey.WORK.COLLECTED.length === 1 &&
+        collectedWorkTimeSurvey.WORK.COLLECTED[0] === null);
 
 const isNavMobile = !isPwa() && isMobile;
 
@@ -83,13 +90,16 @@ const EndSurveyPage = () => {
         border: true,
     };
 
-    const saveDataAndInit = useCallback((surveyData: SurveyData, forceUpdate?: boolean) => {
-        saveData(idSurvey, surveyData, false, forceUpdate).then(() => {
-            initializeSurveysDatasCache().finally(() => {
-                setIsModalDisplayed(true);
+    const saveDataAndInit = useCallback(
+        (surveyData: SurveyData, forceUpdate?: boolean) => {
+            saveData(idSurvey, surveyData, false, forceUpdate).then(() => {
+                initializeSurveysDatasCache().finally(() => {
+                    setIsModalDisplayed(true);
+                });
             });
-        });
-    }, []);
+        },
+        [idSurvey],
+    );
 
     const remoteSaveSurveyAndGoBackHome = useCallback(() => {
         setValue(idSurvey, FieldNameEnum.ISENVOYED, true);
@@ -116,10 +126,14 @@ const EndSurveyPage = () => {
         if (isDemoMode) {
             return saveDataAndInit(surveyData, true);
         }
+        if (!isActivitySurvey && isWorkEmpty(surveyData.data.COLLECTED)) {
+            console.error("Le semainier a son contenu qui vide, on ne l'envoie pas");
+            return handleError();
+        }
         saveData(idSurvey, { ...surveyData.data, stateData: stateData }, false, true)
             .then(navToHome)
             .catch(handleError);
-    }, []);
+    }, [context.source, idSurvey, isActivitySurvey, isDemoMode, saveDataAndInit]);
 
     const onPrevious = useCallback(() => {
         if (isActivitySurvey) {
@@ -133,7 +147,7 @@ const EndSurveyPage = () => {
                     getNavigatePath(EdtRoutesNameEnum.KIND_OF_WEEK),
             );
         }
-    }, []);
+    }, [idSurvey, isActivitySurvey, navigate]);
 
     const validateAndNav = (
         forceQuit: boolean,
@@ -215,6 +229,8 @@ const EndSurveyPage = () => {
                                 {t("common.navigation.send")}
                             </Button>
                         )}
+                    </FlexCenter>
+                    <FlexCenter className={classes.actionBox}>
                         {errorSubmit ? (
                             <Typography className={classes.errorSubmit}>
                                 {t("common.error.error-submit-survey")}

--- a/src/service/api-service/putRemoteData.ts
+++ b/src/service/api-service/putRemoteData.ts
@@ -8,6 +8,12 @@ import { stromaeBackOfficeApiBaseUrl, getHeader } from "./getRemoteData";
 import jwt, { JwtPayload } from "jwt-decode";
 import { logout } from "../../service/auth-service";
 import { transformCollectedArray } from "../../utils/utils";
+import { getCurrentSurveyRootPage } from "../orchestrator-service";
+import { EdtRoutesNameEnum } from "../../enumerations/EdtRoutesNameEnum";
+
+const isActivity = () => {
+    return getCurrentSurveyRootPage() === EdtRoutesNameEnum.ACTIVITY;
+};
 
 export const requestPutSurveyData = (
     idSurvey: string,
@@ -25,7 +31,7 @@ export const requestPutSurveyData = (
 
     // Temporary fix to prevent data from being lost, do not submit data if activity is empty
     const endTime = tempData.data?.COLLECTED?.END_TIME?.COLLECTED;
-    if (!Array.isArray(endTime) || endTime.length === 0) {
+    if (isActivity() && (!Array.isArray(endTime) || endTime.length === 0)) {
         console.log("Skip submitting data");
         return Promise.resolve(data);
     }

--- a/src/service/survey-service.ts
+++ b/src/service/survey-service.ts
@@ -974,7 +974,6 @@ const saveData = (
                     data.stateData = stateData;
                     const revertedTranformedData = revertTransformedArray(data.COLLECTED);
                     data.COLLECTED = revertedTranformedData;
-                    data.COLLECTED = revertedTranformedData;
                     if (data.COLLECTED && "WEEKTYPE" in data.COLLECTED) {
                         const weeklyPlannerData = createDataWeeklyPlanner(data);
                         const WeeklyPlannerVariable: MultiCollected = {


### PR DESCRIPTION
Il y a en réalité deux corrections :
- Pouvoir envoyer le semainier (rendu impossible apparemment avec la correction sur l'envoi vide des activités)
- Empêcher l'envoie du semainier quand il est vide (en se basant sur WORK : qui est le lieu de travail)