### PR TITLE
feat: move to interrogation ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,7 +519,7 @@ This API is used to GET all required nomenclatures for the application such as q
 
 ---
 
-`GET /survey-unit/{id}` : get a survey unit by id
+`GET /interrogations/{id}` : get a survey unit by interrogation id
 
 <details>
 <summary>Answer format</summary>
@@ -545,7 +545,7 @@ This API is used to GET all required nomenclatures for the application such as q
 
 ---
 
-`PUT /survey-unit/{id}` : Edit a survey unit by id
+`PUT /interrogations/{id}` : Edit a survey unit by interrogation id
 
 
 <details>
@@ -1381,12 +1381,12 @@ The application is completely functional offline in browser or in the applicatio
 
 For the reviewer mode, the information recovered is done on two requetes:
 
-- To retrieve the data: VITE_STROMAE_BACK_OFFICE_API_BASE_URL + "api/survey-unit/" + idSurvey + "/data"
-- To retrieve the stateData : VITE_STROMAE_BACK_OFFICE_API_BASE_URL + "api/survey-unit/" + idSurvey + "/state-data"
+- To retrieve the data: VITE_STROMAE_BACK_OFFICE_API_BASE_URL + "api/interrogations/" + idSurvey + "/data"
+- To retrieve the stateData : VITE_STROMAE_BACK_OFFICE_API_BASE_URL + "api/interrogations/" + idSurvey + "/state-data"
 
 For the interviewer mode, the information retrieved is done on the following request:
 
-- VITE_STROMAE_BACK_OFFICE_API_BASE_URL + "api/survey-unit/" + idSurvey.
+- VITE_STROMAE_BACK_OFFICE_API_BASE_URL + "api/interrogations/" + idSurvey.
 
 Same mechanism used to save information relevant to surveys.
 

--- a/README.md
+++ b/README.md
@@ -426,6 +426,7 @@ This API is used to GET the surveys ids to which the surveyed or the surveyers h
   {
     "id": 0,
     "interviewerId": "string",
+    "interrogationId": "string",
     "surveyUnitId": "string",
     "reviewerId": "string",
     "campaignId": "string",
@@ -1381,12 +1382,12 @@ The application is completely functional offline in browser or in the applicatio
 
 For the reviewer mode, the information recovered is done on two requetes:
 
-- To retrieve the data: VITE_STROMAE_BACK_OFFICE_API_BASE_URL + "api/interrogations/" + idSurvey + "/data"
-- To retrieve the stateData : VITE_STROMAE_BACK_OFFICE_API_BASE_URL + "api/interrogations/" + idSurvey + "/state-data"
+- To retrieve the data: VITE_STROMAE_BACK_OFFICE_API_BASE_URL + "api/interrogations/" + interrogationId + "/data"
+- To retrieve the stateData : VITE_STROMAE_BACK_OFFICE_API_BASE_URL + "api/interrogations/" + interrogationId + "/state-data"
 
 For the interviewer mode, the information retrieved is done on the following request:
 
-- VITE_STROMAE_BACK_OFFICE_API_BASE_URL + "api/interrogations/" + idSurvey.
+- VITE_STROMAE_BACK_OFFICE_API_BASE_URL + "api/interrogations/" + interrogationId.
 
 Same mechanism used to save information relevant to surveys.
 

--- a/e2e/e2e-reviewer.test.ts
+++ b/e2e/e2e-reviewer.test.ts
@@ -11,7 +11,7 @@ jest.mock("axios");
 const urlHost = import.meta.env.VITE_KEYCLOAK_REDIRECT_URI;
 const urlUserSurvey = edtOrganisationApiBaseUrl + "api/survey-assigment/interviewer/my-surveys";
 const urlSurveysDataReviewer = edtOrganisationApiBaseUrl + "api/survey-assigment/reviewer/my-surveys";
-const urlSurveyData = stromaeBackOfficeApiBaseUrl + "api/survey-unit/";
+const urlSurveyData = stromaeBackOfficeApiBaseUrl + "api/interrogations/";
 
 const userServiceMock = jest.fn(isReviewer).mockImplementationOnce(() => true);
 
@@ -43,7 +43,7 @@ describe("App.ts", () => {
     };
 
     const mockSurveyData = (request: any, url: string) => {
-        const idSurvey = Number.parseInt(url.split("survey-unit/")[1].split("-")[1] ?? 0);
+        const idSurvey = Number.parseInt(url.split("interrogations/")[1].split("-")[1] ?? 0);
         request.respond({
             headers: mockHeaders,
             body: JSON.stringify(userData[idSurvey - 1]),

--- a/e2e/e2e.test.ts
+++ b/e2e/e2e.test.ts
@@ -6,7 +6,7 @@ jest.mock("axios");
 
 const urlHost = import.meta.env.VITE_KEYCLOAK_REDIRECT_URI;
 const urlUserSurvey = edtOrganisationApiBaseUrl + "api/survey-assigment/interviewer/my-surveys";
-const urlSurveyData = stromaeBackOfficeApiBaseUrl + "api/survey-unit/";
+const urlSurveyData = stromaeBackOfficeApiBaseUrl + "api/interrogations/";
 
 describe("App.ts", () => {
     let browser;
@@ -29,7 +29,7 @@ describe("App.ts", () => {
     };
 
     const mockSurveyData = (request: any, url: string) => {
-        const idSurvey = Number.parseInt(url.split("survey-unit/")[1].split("-")[1] ?? 0);
+        const idSurvey = Number.parseInt(url.split("interrogations/")[1].split("-")[1] ?? 0);
         request.respond({
             headers: mockHeaders,
             body: JSON.stringify(userData[idSurvey - 1]),

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -20,6 +20,7 @@ export default tseslint.config(
         rules: {
             ...reactHooks.configs.recommended.rules,
             "react-refresh/only-export-components": ["warn", { allowConstantExport: true }],
+            "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_$" }],
         },
     },
 );

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "edt",
-    "version": "4.6.0",
-    "dateVersion": "13/08/2025",
+    "version": "4.6.1",
+    "dateVersion": "21/08/2025",
     "licence": "MIT",
     "type": "module",
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "edt",
-    "version": "4.6.1",
-    "dateVersion": "21/08/2025",
+    "version": "4.6.2",
+    "dateVersion": "22/08/2025",
     "licence": "MIT",
     "type": "module",
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "edt",
-    "version": "4.5.1",
-    "dateVersion": "10/07/2025",
+    "version": "4.6.0",
+    "dateVersion": "13/08/2025",
     "licence": "MIT",
     "type": "module",
     "dependencies": {

--- a/src/documentation/README.md
+++ b/src/documentation/README.md
@@ -503,7 +503,7 @@ This API is used to GET all required nomenclatures for the application such as q
 
 ---
 
-`GET /survey-unit/{id}` : get a survey unit by id
+`GET /interrogations/{id}` : get a survey unit by id
 
 <details>
 <summary>Answer format</summary>
@@ -529,7 +529,7 @@ This API is used to GET all required nomenclatures for the application such as q
 
 ---
 
-`PUT /survey-unit/{id}` : Edit a survey unit by id
+`PUT /interrogations/{id}` : Edit a survey unit by id
 
 
 <details>
@@ -1395,12 +1395,12 @@ The application is completely functional offline in browser or in the applicatio
 
 For the reviewer mode, the information recovered is done on two requetes:
 
-- To retrieve the data: VITE_STROMAE_BACK_OFFICE_API_BASE_URL + "api/survey-unit/" + idSurvey + "/data"
-- To retrieve the stateData : VITE_STROMAE_BACK_OFFICE_API_BASE_URL + "api/survey-unit/" + idSurvey + "/state-data"
+- To retrieve the data: VITE_STROMAE_BACK_OFFICE_API_BASE_URL + "api/interrogations/" + idSurvey + "/data"
+- To retrieve the stateData : VITE_STROMAE_BACK_OFFICE_API_BASE_URL + "api/interrogations/" + idSurvey + "/state-data"
 
 For the interviewer mode, the information retrieved is done on the following request:
 
-- VITE_STROMAE_BACK_OFFICE_API_BASE_URL + "api/survey-unit/" + idSurvey.
+- VITE_STROMAE_BACK_OFFICE_API_BASE_URL + "api/interrogations/" + idSurvey.
 
 Same mechanism used to save information relevant to surveys.
 

--- a/src/documentation/README.md
+++ b/src/documentation/README.md
@@ -410,6 +410,7 @@ This API is used to GET the surveys ids to which the surveyed or the surveyers h
   {
     "id": 0,
     "interviewerId": "string",
+    "interrogationId": "string",
     "surveyUnitId": "string",
     "reviewerId": "string",
     "campaignId": "string",
@@ -1395,12 +1396,12 @@ The application is completely functional offline in browser or in the applicatio
 
 For the reviewer mode, the information recovered is done on two requetes:
 
-- To retrieve the data: VITE_STROMAE_BACK_OFFICE_API_BASE_URL + "api/interrogations/" + idSurvey + "/data"
-- To retrieve the stateData : VITE_STROMAE_BACK_OFFICE_API_BASE_URL + "api/interrogations/" + idSurvey + "/state-data"
+- To retrieve the data: VITE_STROMAE_BACK_OFFICE_API_BASE_URL + "api/interrogations/" + interrogationId + "/data"
+- To retrieve the stateData : VITE_STROMAE_BACK_OFFICE_API_BASE_URL + "api/interrogations/" + interrogationId + "/state-data"
 
 For the interviewer mode, the information retrieved is done on the following request:
 
-- VITE_STROMAE_BACK_OFFICE_API_BASE_URL + "api/interrogations/" + idSurvey.
+- VITE_STROMAE_BACK_OFFICE_API_BASE_URL + "api/interrogations/" + interrogationId.
 
 Same mechanism used to save information relevant to surveys.
 

--- a/src/interface/entity/Api.ts
+++ b/src/interface/entity/Api.ts
@@ -6,6 +6,7 @@ export interface UserSurveys {
     campaignId: string;
     subCampaignId?: string;
     interviewerId: string;
+    interrogationId: string;
     questionnaireModelId: string;
     reviewerId?: string;
     surveyUnitId: string;

--- a/src/orchestrator/Orchestrator.tsx
+++ b/src/orchestrator/Orchestrator.tsx
@@ -48,52 +48,6 @@ const renderLoading = () => {
     );
 };
 
-// const getDataOfLoop = (collected: any, editedSaved: any, iteration: number | undefined) => {
-//     let maxLenght = Number(localStorage.getItem("loopSize") ?? 0);
-//     for (let i = 0; i < maxLenght; i++) {
-//         if (i != iteration || (collected[i] == null && i == iteration)) {
-//             collected[i] = editedSaved[i];
-//         }
-//     }
-//     return collected;
-// };
-
-// const getDataOfCurrentBinding = (
-//     collected: any,
-//     edited: any,
-//     collectedSaved: any,
-//     editedSaved: any,
-//     dataOfField: any,
-//     iteration: number | undefined,
-// ) => {
-//     // partie collected dejà set (mode enquete) -> set values of collected (value current lunawtic) to edited
-//     // and collected remains with the collected value on bdd
-
-//     if (collected) {
-//         if (editedSaved && Array.isArray(collected)) {
-//             collected = getDataOfLoop(collected, editedSaved, iteration);
-//         }
-//         dataOfField.EDITED = collected;
-//         dataOfField.COLLECTED = collectedSaved;
-//     } else if (dataOfField) {
-//         dataOfField.EDITED = edited ?? editedSaved;
-//         dataOfField.COLLECTED = collectedSaved;
-//     }
-
-//     return dataOfField;
-// };
-
-//prop is for activity and prop being modified
-// const isPropCurrent = (prop: string, bindings?: string[]) => {
-//     return bindings?.includes(prop) ?? false;
-// };
-
-//return a copy of a object
-// const copyObject = (object: any) => {
-//     if (object == null) return object;
-//     return Array.isArray(object) ? [...object] : JSON.parse(JSON.stringify(object));
-// };
-
 const isWorkTime = (source: LunaticModel | undefined) => {
     return source ? source.label == "WorkTime" : getCurrentPageSource().label == "WorkTime";
 };
@@ -110,95 +64,6 @@ const propsWorkTime = (source: LunaticModel): string[] => {
     );
     return uniqueBindingDependencies;
 };
-
-//if weekly planner, doesn't distinction edited/collected, so edited/collected get value of collected
-// const setDataOfWorkTimeReviewer = (
-//     source: LunaticModel | undefined,
-//     data: LunaticData | undefined,
-//     dataCollected: any,
-// ) => {
-//     if (!source) {
-//         source = getCurrentPageSource();
-//     }
-
-//     const weeklyPlannerProps = propsWorkTime(source);
-//     weeklyPlannerProps.forEach(prop => {
-//         let dataOfField = dataCollected[prop];
-//         const collectedSaved = data?.COLLECTED?.[prop]?.COLLECTED;
-//         const editedSaved = data?.COLLECTED?.[prop]?.EDITED;
-//         if (dataOfField) {
-//             dataOfField.EDITED = editedSaved;
-//             dataOfField.COLLECTED = collectedSaved;
-//         }
-//     });
-
-//     return dataCollected;
-// };
-
-// const setDataOfActivityReviewer = (
-//     dataCollected: any,
-//     data: LunaticData | undefined,
-//     components: any,
-//     iteration: number | undefined,
-// ) => {
-//     const bindings: string[] = components?.filter(
-//         (component: any) => component.componentType != "Sequence",
-//     )[0]?.bindingDependencies;
-//     for (let prop in FieldNameEnumActivity as any) {
-//         let dataOfField = dataCollected[prop];
-//         const collected = dataOfField?.COLLECTED;
-//         const edited = dataOfField?.EDITED;
-//         const editedSaved = data?.COLLECTED?.[prop]?.EDITED;
-//         const collectedSaved = data?.COLLECTED?.[prop]?.COLLECTED;
-//         //prop activity + prop currently being edited
-//         if (isPropCurrent(prop, bindings)) {
-//             //get data of current prop ->
-//             //COLLECTED : value of bdd (COLLECTED)
-//             //EDITED: if exist EDITED -> value of lunatic for value[iteration], other -> value of bdd (EDITED)
-//             dataOfField = getDataOfCurrentBinding(
-//                 copyObject(collected),
-//                 copyObject(edited),
-//                 copyObject(collectedSaved),
-//                 copyObject(editedSaved),
-//                 dataOfField,
-//                 iteration,
-//             );
-//         } else if (dataOfField) {
-//             //prop activity + prop not currently being edited,
-//             //so edited get value of edited in bdd, and collected get value of partie collected in bdd
-//             dataOfField.EDITED = copyObject(editedSaved);
-//             dataOfField.COLLECTED = copyObject(collectedSaved);
-//         }
-//         dataCollected[prop] = dataOfField;
-//     }
-//     return dataCollected;
-// };
-
-//data of a reviewer
-// const getDataReviewer = (
-//     getData: any,
-//     data: LunaticData | undefined,
-//     components: any,
-//     iteration: number | undefined,
-//     source?: LunaticModel,
-// ) => {
-//     const callbackholder = getData();
-//     let dataCollected = callbackholder.COLLECTED;
-
-//     if (!source) {
-//         source = getCurrentPageSource();
-//     }
-//     // data -> get data of bdd, callbackholder -> lunatic / current data
-//     if (callbackholder && dataCollected) {
-//         if (isWorkTime(source)) {
-//             dataCollected = setDataOfWorkTimeReviewer(source, data, dataCollected);
-//         } else {
-//             dataCollected = setDataOfActivityReviewer(dataCollected, data, components, iteration);
-//         }
-//     }
-//     callbackholder.COLLECTED = dataCollected;
-//     return callbackholder;
-// };
 
 /**
  * Retrieves and updates interviewer data.
@@ -328,12 +193,6 @@ export const OrchestratorForStories = (props: OrchestratorProps) => {
     const getDataLocal = () => {
         // Since we want to disable EDITED, only consider collected data
         return getDataInterviewer(getData, data, source);
-        /*
-        const dataLocal = isReviewer()
-            ? getDataReviewer(getData, data, components, iteration)
-            : getDataInterviewer(getData, data, source);
-        return dataLocal;
-         */
     };
 
     callbackHolder.getData = getDataLocal;

--- a/src/pages/home-surveyed/HomeSurveyed.tsx
+++ b/src/pages/home-surveyed/HomeSurveyed.tsx
@@ -80,10 +80,6 @@ const HomeSurveyedPage = () => {
 
     const initHome = (idsSurveysSelected: string[]) => {
         initializeHomeSurveys(idHousehold ?? "").then(() => {
-            // initializeSurveysDatasCache(idsSurveysSelected).finally(() => {
-
-            // });
-
             userDatas = userDatasMap();
             if (getData(idsSurveysSelected[0]) != undefined) {
                 setState(getData(idsSurveysSelected[0]));
@@ -94,18 +90,27 @@ const HomeSurveyedPage = () => {
     };
 
     useEffect(() => {
-        if (navigator.onLine && role === EdtUserRightsEnum.SURVEYED) {
-            initializeDatas(setError).then(() => {
-                setInitialized(true);
-            });
-        } else if (role === EdtUserRightsEnum.SURVEYED) {
-            initializeDatas(setError).then(() => {
-                setInitialized(true);
-                setState({});
-            });
+        if (role === EdtUserRightsEnum.SURVEYED) {
+            if (navigator.onLine) {
+                initializeDatas(setError).then(() => {
+                    setInitialized(true);
+                });
+            } else {
+                initializeDatas(setError).then(() => {
+                    setInitialized(true);
+                    setState({});
+                });
+            }
+            return;
         }
 
-        if (role == EdtUserRightsEnum.REVIEWER && !isDemo) {
+        if (role === EdtUserRightsEnum.REVIEWER) {
+            if (isDemo) {
+                const userDatas = userDatasMap();
+                setDatas(userDatas);
+                return;
+            }
+
             userDatas = userDatasMap();
             const idsSurveysSelected = userDatas
                 .map(data => data.data.surveyUnitId)
@@ -113,6 +118,7 @@ const HomeSurveyedPage = () => {
                     (survey: string) =>
                         !survey.startsWith("activitySurvey") && !survey.startsWith("workTimeSurvey"),
                 );
+
             if (navigator.onLine) {
                 getRemoteSavedSurveysDatas(idsSurveysSelected, setError).then(() => {
                     initHome(idsSurveysSelected);
@@ -120,9 +126,6 @@ const HomeSurveyedPage = () => {
             } else {
                 initHome(idsSurveysSelected);
             }
-        } else if (role == EdtUserRightsEnum.REVIEWER && isDemo) {
-            let userDatas = userDatasMap();
-            setDatas(userDatas);
         }
     }, []);
 

--- a/src/service/api-service/getRemoteData.ts
+++ b/src/service/api-service/getRemoteData.ts
@@ -25,7 +25,7 @@ axios.interceptors.response.use(
 export const getHeader = (origin?: string, userToken?: string) => {
     return {
         headers: {
-            "Authorization": "Bearer " + (userToken ?? getUserToken()),
+            "Authorization": `Bearer ${userToken ?? getUserToken()}`,
             "Access-Control-Allow-Origin": origin ?? "*",
             "Content-type": "application/json",
         },
@@ -38,7 +38,7 @@ export const fetchUserSurveysInfo = (
     return new Promise(resolve => {
         axios
             .get(
-                edtOrganisationApiBaseUrl + "api/survey-assigment/interviewer/my-surveys",
+                `${edtOrganisationApiBaseUrl}api/survey-assigment/interviewer/my-surveys`,
                 getHeader(edtOrganisationApiBaseUrl),
             )
             .then(response => {
@@ -61,7 +61,7 @@ export const fetchReviewerSurveysAssignments = (
     return new Promise(resolve => {
         axios
             .get(
-                edtOrganisationApiBaseUrl + "api/survey-assigment/reviewer/my-surveys",
+                `${edtOrganisationApiBaseUrl}api/survey-assigment/reviewer/my-surveys`,
                 getHeader(edtOrganisationApiBaseUrl),
             )
             .then(response => {

--- a/src/service/api-service/getRemoteData.ts
+++ b/src/service/api-service/getRemoteData.ts
@@ -1,10 +1,9 @@
 import axios from "axios";
 import { ErrorCodeEnum } from "../../enumerations/ErrorCodeEnum";
 import { StateData, SurveyData, UserSurveys } from "../../interface/entity/Api";
-import { LunaticData, ReferentielData, SourceData } from "../../interface/lunatic/Lunatic";
+import { LunaticData } from "../../interface/lunatic/Lunatic";
 import { initStateData, initSurveyData } from "../survey-service";
-import { getUserToken, isReviewer } from "../user-service";
-import { ReferentielsEnum } from "../../enumerations/ReferentielsEnum";
+import { getUserToken } from "../user-service";
 import { revertTransformedArray } from "../../utils/utils";
 
 export const edtOrganisationApiBaseUrl = import.meta.env.VITE_EDT_ORGANISATION_API_BASE_URL;
@@ -33,52 +32,6 @@ export const getHeader = (origin?: string, userToken?: string) => {
     };
 };
 
-export const fetchRemoteReferentiels = (
-    setError: (error: ErrorCodeEnum) => void,
-): Promise<ReferentielData> => {
-    let refs: ReferentielData = {
-        [ReferentielsEnum.ACTIVITYNOMENCLATURE]: [],
-        [ReferentielsEnum.ACTIVITYAUTOCOMPLETE]: [],
-        [ReferentielsEnum.ROUTE]: [],
-        [ReferentielsEnum.MEANOFTRANSPORT]: [],
-        [ReferentielsEnum.ACTIVITYSECONDARYACTIVITY]: [],
-        [ReferentielsEnum.ROUTESECONDARYACTIVITY]: [],
-        [ReferentielsEnum.LOCATION]: [],
-        [ReferentielsEnum.KINDOFWEEK]: [],
-        [ReferentielsEnum.KINDOFDAY]: [],
-        [ReferentielsEnum.ACTIVITYGOAL]: [],
-    };
-    let refsEndPoints: string[] = [];
-    Object.values(ReferentielsEnum).forEach(value => {
-        refsEndPoints.push("api/nomenclature/" + value);
-    });
-
-    return new Promise(resolve => {
-        axios
-            .all(
-                refsEndPoints.map(endPoint =>
-                    axios.get(
-                        stromaeBackOfficeApiBaseUrl + endPoint,
-                        getHeader(stromaeBackOfficeApiBaseUrl),
-                    ),
-                ),
-            )
-            .then(res => {
-                Object.values(ReferentielsEnum).forEach((key, index) => {
-                    refs[key as ReferentielsEnum] = res[index].data;
-                });
-                resolve(refs);
-            })
-            .catch(err => {
-                if (err.response?.status === 403) {
-                    setError(ErrorCodeEnum.NO_RIGHTS);
-                } else {
-                    setError(ErrorCodeEnum.UNREACHABLE_NOMENCLATURES);
-                }
-            });
-    });
-};
-
 export const fetchUserSurveysInfo = (
     setError: (error: ErrorCodeEnum) => void,
 ): Promise<UserSurveys[]> => {
@@ -102,42 +55,9 @@ export const fetchUserSurveysInfo = (
     });
 };
 
-export const fetchSurveysSourcesByIds = (
-    sourcesIds: string[],
-    setError: (error: ErrorCodeEnum) => void,
-): Promise<SourceData> => {
-    let sources: any = {};
-    let sourcesEndPoints: string[] = [];
-    sourcesIds.forEach(sourceId => sourcesEndPoints.push("api/questionnaire/" + sourceId));
-    return new Promise(resolve => {
-        axios
-            .all(
-                sourcesEndPoints.map(endPoint =>
-                    axios.get(
-                        stromaeBackOfficeApiBaseUrl + endPoint,
-                        getHeader(stromaeBackOfficeApiBaseUrl),
-                    ),
-                ),
-            )
-            .then(res => {
-                sourcesIds.forEach((idSource, index) => {
-                    sources[idSource] = res[index].data.value;
-                });
-                resolve(sources as SourceData);
-            })
-            .catch(err => {
-                if (err.response?.status === 403) {
-                    setError(ErrorCodeEnum.NO_RIGHTS);
-                } else {
-                    setError(ErrorCodeEnum.UNREACHABLE_SOURCE);
-                }
-            });
-    });
-};
-
 export const fetchReviewerSurveysAssignments = (
     setError: (error: ErrorCodeEnum) => void,
-): Promise<any> => {
+): Promise<UserSurveys[]> => {
     return new Promise(resolve => {
         axios
             .get(
@@ -158,13 +78,13 @@ export const fetchReviewerSurveysAssignments = (
 };
 
 export const remoteGetSurveyData = (
-    idSurvey: string,
+    interrogationId: string,
     setError?: (error: ErrorCodeEnum) => void,
 ): Promise<SurveyData> => {
     return new Promise(resolve => {
         axios
             .get(
-                stromaeBackOfficeApiBaseUrl + "api/interrogations/" + idSurvey + "/data",
+                `${stromaeBackOfficeApiBaseUrl}api/interrogations/${interrogationId}/data`,
                 getHeader(stromaeBackOfficeApiBaseUrl),
             )
             .then(response => {
@@ -190,13 +110,13 @@ export const remoteGetSurveyData = (
 };
 
 export const remoteGetSurveyStateData = (
-    idSurvey: string,
+    interrogationId: string,
     setError?: (error: ErrorCodeEnum) => void,
 ): Promise<StateData> => {
     return new Promise(resolve => {
         axios
             .get(
-                stromaeBackOfficeApiBaseUrl + "api/interrogations/" + idSurvey + "/state-data",
+                `${stromaeBackOfficeApiBaseUrl}api/interrogations/${interrogationId}/state-data`,
                 getHeader(stromaeBackOfficeApiBaseUrl),
             )
             .then(response => {
@@ -216,31 +136,16 @@ export const remoteGetSurveyStateData = (
             });
     });
 };
-export const remoteGetSurveyDataSurveyed = (
-    idSurvey: string,
-    setError: (error: ErrorCodeEnum) => void,
-): Promise<SurveyData> => {
-    return remoteGetSurveyData(idSurvey, setError).then(data => {
-        return remoteGetSurveyStateData(idSurvey, setError).then((stateData: StateData) => {
-            return new Promise(resolve => {
-                const surveyData: SurveyData = {
-                    stateData: stateData,
-                    data: data,
-                };
-                resolve(surveyData);
-            });
-        });
-    });
-};
 
 export const requestGetDataReviewer = (
     idSurvey: string,
+    interrogationId: string,
     setError: (error: ErrorCodeEnum) => void,
 ): Promise<LunaticData> => {
     return new Promise<LunaticData>(resolve => {
         axios
             .get(
-                stromaeBackOfficeApiBaseUrl + "api/interrogations/" + idSurvey + "/data",
+                `${stromaeBackOfficeApiBaseUrl}api/interrogations/${interrogationId}/data`,
                 getHeader(stromaeBackOfficeApiBaseUrl),
             )
             .then(response => {
@@ -264,52 +169,7 @@ export const requestGetDataReviewer = (
                 } else {
                     console.error(err);
                     setError(ErrorCodeEnum.UNREACHABLE_SURVEYS_DATAS);
-                    //requestGetDataReviewer(idSurvey, setError);
                 }
             });
     });
-};
-
-export const requestGetSurveyDataReviewer = (
-    idSurvey: string,
-    setError: (error: ErrorCodeEnum) => void,
-): Promise<SurveyData> => {
-    return requestGetDataReviewer(idSurvey, setError).then(data => {
-        return remoteGetSurveyStateData(idSurvey, setError).then((stateData: StateData) => {
-            return new Promise(resolve => {
-                const surveyData: SurveyData = {
-                    stateData: stateData,
-                    data: data,
-                };
-                resolve(surveyData);
-            });
-        });
-    });
-};
-
-/**
- * @deprecated This function is deprecated and it is not used anymore.
- * Please use `requestGetSurveyDataReviewer` instead.
- */
-export const remoteGetSurveyDataReviewer = (
-    idSurvey: string,
-    setError: (error: ErrorCodeEnum) => void,
-): Promise<SurveyData> => {
-    const isReviewerMode = isReviewer();
-    if (!isReviewerMode) setError?.(ErrorCodeEnum.NO_RIGHTS);
-    return requestGetSurveyDataReviewer(idSurvey, setError)
-        .then(response => {
-            return response;
-        })
-        .catch(err => {
-            if (err.response?.status === 403) {
-                setError?.(ErrorCodeEnum.NO_RIGHTS);
-            } else {
-                return {
-                    data: initSurveyData(idSurvey),
-                    stateData: initStateData(),
-                };
-            }
-            return Promise.reject(err);
-        });
 };

--- a/src/service/api-service/getRemoteData.ts
+++ b/src/service/api-service/getRemoteData.ts
@@ -164,7 +164,7 @@ export const remoteGetSurveyData = (
     return new Promise(resolve => {
         axios
             .get(
-                stromaeBackOfficeApiBaseUrl + "api/survey-unit/" + idSurvey + "/data",
+                stromaeBackOfficeApiBaseUrl + "api/interrogations/" + idSurvey + "/data",
                 getHeader(stromaeBackOfficeApiBaseUrl),
             )
             .then(response => {
@@ -196,7 +196,7 @@ export const remoteGetSurveyStateData = (
     return new Promise(resolve => {
         axios
             .get(
-                stromaeBackOfficeApiBaseUrl + "api/survey-unit/" + idSurvey + "/state-data",
+                stromaeBackOfficeApiBaseUrl + "api/interrogations/" + idSurvey + "/state-data",
                 getHeader(stromaeBackOfficeApiBaseUrl),
             )
             .then(response => {
@@ -240,7 +240,7 @@ export const requestGetDataReviewer = (
     return new Promise<LunaticData>(resolve => {
         axios
             .get(
-                stromaeBackOfficeApiBaseUrl + "api/survey-unit/" + idSurvey + "/data",
+                stromaeBackOfficeApiBaseUrl + "api/interrogations/" + idSurvey + "/data",
                 getHeader(stromaeBackOfficeApiBaseUrl),
             )
             .then(response => {

--- a/src/service/api-service/putRemoteData.ts
+++ b/src/service/api-service/putRemoteData.ts
@@ -35,13 +35,13 @@ export const requestPutSurveyData = (
     }
 
     const putLunaticData = axios.put(
-        `${stromaeBackOfficeApiBaseUrl}api/survey-unit/${idSurvey}/data`,
+        `${stromaeBackOfficeApiBaseUrl}api/interrogations/${idSurvey}/data`,
         tempData.data,
         getHeader(stromaeBackOfficeApiBaseUrl, token),
     );
 
     const putStateData = axios.put(
-        `${stromaeBackOfficeApiBaseUrl}api/survey-unit/${idSurvey}/state-data`,
+        `${stromaeBackOfficeApiBaseUrl}api/interrogations/${idSurvey}/state-data`,
         stateData,
         getHeader(stromaeBackOfficeApiBaseUrl, token),
     );
@@ -121,7 +121,7 @@ export const requestPutDataReviewer = (
     return new Promise<LunaticData>(resolve => {
         axios
             .put(
-                stromaeBackOfficeApiBaseUrl + "api/survey-unit/" + idSurvey + "/data",
+                stromaeBackOfficeApiBaseUrl + "api/interrogations/" + idSurvey + "/data",
                 tempData,
                 getHeader(stromaeBackOfficeApiBaseUrl, token),
             )
@@ -139,7 +139,7 @@ export const requestPutStateReviewer = (
     return new Promise<StateData>(resolve => {
         axios
             .put(
-                stromaeBackOfficeApiBaseUrl + "api/survey-unit/" + idSurvey + "/state-data",
+                stromaeBackOfficeApiBaseUrl + "api/interrogations/" + idSurvey + "/state-data",
                 data,
                 getHeader(stromaeBackOfficeApiBaseUrl, token),
             )

--- a/src/service/api-service/putRemoteData.ts
+++ b/src/service/api-service/putRemoteData.ts
@@ -10,8 +10,8 @@ import { logout } from "../../service/auth-service";
 import { transformCollectedArray } from "../../utils/utils";
 import { SourcesEnum } from "../../enumerations/SourcesEnum";
 
-export const requestPutSurveyData = (
-    idSurvey: string,
+const requestPutSurveyData = (
+    interrogationId: string,
     data: SurveyData,
     surveyType: SourcesEnum,
     token?: string,
@@ -35,13 +35,13 @@ export const requestPutSurveyData = (
     }
 
     const putLunaticData = axios.put(
-        `${stromaeBackOfficeApiBaseUrl}api/interrogations/${idSurvey}/data`,
+        `${stromaeBackOfficeApiBaseUrl}api/interrogations/${interrogationId}/data`,
         tempData.data,
         getHeader(stromaeBackOfficeApiBaseUrl, token),
     );
 
     const putStateData = axios.put(
-        `${stromaeBackOfficeApiBaseUrl}api/interrogations/${idSurvey}/state-data`,
+        `${stromaeBackOfficeApiBaseUrl}api/interrogations/${interrogationId}/state-data`,
         stateData,
         getHeader(stromaeBackOfficeApiBaseUrl, token),
     );
@@ -56,7 +56,7 @@ export const requestPutSurveyData = (
 };
 
 export const remotePutSurveyData = (
-    idSurvey: string,
+    interrogationId: string,
     data: SurveyData,
     surveyType: SourcesEnum,
 ): Promise<SurveyData> => {
@@ -67,23 +67,23 @@ export const remotePutSurveyData = (
     const tokenExpiresAt = jwt<JwtPayload>(getUserToken() ?? "").exp;
     // * 1000 because tokenExpiresAt is in seconds and now.getTime() in milliseconds
     if (!tokenExpiresAt || tokenExpiresAt * 1000 < now.getTime()) {
-        let auth = getAuth();
+        const auth = getAuth();
         return auth.userManager
             .signinSilent()
             .then((user: User | null) => {
-                return requestPutSurveyData(idSurvey, data, surveyType, user?.access_token);
+                return requestPutSurveyData(interrogationId, data, surveyType, user?.access_token);
             })
             .catch(err => {
                 logout();
                 return Promise.reject(err);
             });
     } else {
-        return requestPutSurveyData(idSurvey, data, surveyType);
+        return requestPutSurveyData(interrogationId, data, surveyType);
     }
 };
 
 export const remotePutSurveyDataReviewer = (
-    idSurvey: string,
+    interrogationId: string,
     stateData: StateData,
     data: LunaticData,
 ): Promise<SurveyData> => {
@@ -91,23 +91,28 @@ export const remotePutSurveyDataReviewer = (
     const tokenExpiresAt = jwt<JwtPayload>(getUserToken() ?? "").exp;
     // * 1000 because tokenExpiresAt is in seconds and now.getTime() in milliseconds
     if (!tokenExpiresAt || tokenExpiresAt * 1000 < now.getTime()) {
-        let auth = getAuth();
+        const auth = getAuth();
         return auth.userManager
             .signinSilent()
             .then((user: User | null) => {
-                return requestPutSurveyDataReviewer(idSurvey, data, stateData, user?.access_token);
+                return requestPutSurveyDataReviewer(
+                    interrogationId,
+                    data,
+                    stateData,
+                    user?.access_token,
+                );
             })
             .catch(err => {
                 logout();
                 return Promise.reject(err);
             });
     } else {
-        return requestPutSurveyDataReviewer(idSurvey, data, stateData);
+        return requestPutSurveyDataReviewer(interrogationId, data, stateData);
     }
 };
 
-export const requestPutDataReviewer = (
-    idSurvey: string,
+const requestPutDataReviewer = (
+    interrogationId: string,
     data: LunaticData,
     token?: string,
 ): Promise<LunaticData> => {
@@ -121,7 +126,7 @@ export const requestPutDataReviewer = (
     return new Promise<LunaticData>(resolve => {
         axios
             .put(
-                stromaeBackOfficeApiBaseUrl + "api/interrogations/" + idSurvey + "/data",
+                `${stromaeBackOfficeApiBaseUrl}api/interrogations/${interrogationId}/data`,
                 tempData,
                 getHeader(stromaeBackOfficeApiBaseUrl, token),
             )
@@ -131,15 +136,15 @@ export const requestPutDataReviewer = (
     });
 };
 
-export const requestPutStateReviewer = (
-    idSurvey: string,
+const requestPutStateReviewer = (
+    interrogationId: string,
     data: StateData,
     token?: string,
 ): Promise<StateData> => {
     return new Promise<StateData>(resolve => {
         axios
             .put(
-                stromaeBackOfficeApiBaseUrl + "api/interrogations/" + idSurvey + "/state-data",
+                `${stromaeBackOfficeApiBaseUrl}api/interrogations/${interrogationId}/state-data`,
                 data,
                 getHeader(stromaeBackOfficeApiBaseUrl, token),
             )
@@ -159,14 +164,14 @@ export const requestPutStateReviewer = (
     });
 };
 
-export const requestPutSurveyDataReviewer = (
-    idSurvey: string,
+const requestPutSurveyDataReviewer = (
+    interrogationId: string,
     data: LunaticData,
     stateData: StateData,
     token?: string,
 ): Promise<SurveyData> => {
-    return requestPutDataReviewer(idSurvey, data, token).then(() => {
-        requestPutStateReviewer(idSurvey, stateData, token);
+    return requestPutDataReviewer(interrogationId, data, token).then(() => {
+        requestPutStateReviewer(interrogationId, stateData, token);
         const surveyData: SurveyData = {
             stateData: stateData,
             data: data,

--- a/src/service/survey-service.ts
+++ b/src/service/survey-service.ts
@@ -148,6 +148,32 @@ const initializeRefs = () => {
     });
 };
 
+/**
+ * Populate the surveyIdToInterrogationId global variable to get the
+ * interrogation id from our survey id to get / put data through the
+ * interrogation endpoint.
+ */
+const initInterrogationIdMapping = (setError: (error: ErrorCodeEnum) => void) => {
+    if (navigator.onLine) {
+        return fetchUserSurveysInfo(setError).then(userSurveyData => {
+            // Compute the interrogation ids related to our user
+            userSurveyData.forEach(surveyData => {
+                surveyIdToInterrogationId.set(surveyData.surveyUnitId, surveyData.interrogationId);
+            });
+        });
+    } else {
+        return lunaticDatabase.get(USER_SURVEYS_DATA).then((data: LunaticData | undefined) => {
+            const userDaras = data as UserSurveysData;
+            const userSurveyData = userDaras.data;
+
+            // Compute the interrogation ids related to our user
+            userSurveyData.forEach(surveyData => {
+                surveyIdToInterrogationId.set(surveyData.surveyUnitId, surveyData.interrogationId);
+            });
+        });
+    }
+};
+
 const initDataForSurveys = (setError: (error: ErrorCodeEnum) => void) => {
     if (navigator.onLine) {
         return fetchUserSurveysInfo(setError).then(userSurveyData => {
@@ -243,7 +269,10 @@ const initDataForSurveys = (setError: (error: ErrorCodeEnum) => void) => {
 
 const initializeSurveysIdsAndSources = (setError: (error: ErrorCodeEnum) => void): Promise<unknown> => {
     const promises: Promise<unknown>[] = [];
-    return lunaticDatabase.get(SURVEYS_IDS).then(data => {
+    return lunaticDatabase.get(SURVEYS_IDS).then(async data => {
+        // map the interrogation id with our survey ids
+        await initInterrogationIdMapping(setError);
+
         const surveyIdsData = data as SurveysIds;
         const existSurveysIds = surveyIdsData?.[SurveysIdsEnum.ALL_SURVEYS_IDS].length > 0;
 

--- a/src/service/survey-service.ts
+++ b/src/service/survey-service.ts
@@ -10,7 +10,7 @@ import { ReferentielsEnum } from "../enumerations/ReferentielsEnum";
 import { SourcesEnum } from "../enumerations/SourcesEnum";
 import { StateHouseholdEnum } from "../enumerations/StateHouseholdEnum";
 import { SurveysIdsEnum } from "../enumerations/SurveysIdsEnum";
-import { t } from "i18next";
+import { t, TFunction } from "i18next";
 import _ from "lodash";
 import { TabData } from "../interface/component/Component";
 import { StateData, SurveyData, UserSurveys } from "../interface/entity/Api";
@@ -19,8 +19,6 @@ import { Person } from "../interface/entity/Person";
 import { StatsHousehold } from "../interface/entity/StatsHouseHold";
 import {
     Collected,
-    DATA_STATE,
-    DataState,
     LunaticModel,
     LunaticModelComponent,
     LunaticModelVariable,
@@ -34,7 +32,6 @@ import {
     USER_SURVEYS_DATA,
     UserSurveysData,
 } from "../interface/lunatic/Lunatic";
-import { AuthContextProps } from "oidc-react";
 import { NavigateFunction } from "react-router-dom";
 import {
     fetchReviewerSurveysAssignments,
@@ -100,6 +97,9 @@ let userDatas: UserSurveys[] = [];
 let surveysData: UserSurveys[] = [];
 let initData = false;
 
+/** Map used to get the interrogation id related to our survey unit id. */
+const surveyIdToInterrogationId = new Map<string, string>();
+
 const toIgnoreForRoute = [
     FieldNameEnum.PLACE,
     FieldNameEnum.MAINACTIVITY_ID,
@@ -126,40 +126,13 @@ const toIgnoreForActivity = [
 ];
 
 const initializeDatas = (setError: (error: ErrorCodeEnum) => void): Promise<boolean> => {
-    const promisesToWait: Promise<any>[] = [];
+    const promisesToWait: Promise<unknown>[] = [];
     return new Promise(resolve => {
         promisesToWait.push(initializeRefs());
         promisesToWait.push(initializeSurveysIdsAndSources(setError));
         Promise.all(promisesToWait).then(() => {
             resolve(true);
         });
-    });
-};
-
-/**
- * @deprecated useData should not be set in the database
- */
-const initPropsAuth = (auth: AuthContextProps): Promise<DataState> => {
-    const dataState: DataState = {
-        data: {
-            userData: {
-                access_token: auth.userData?.access_token,
-                expires_at: auth.userData?.expires_at,
-                id_token: auth.userData?.id_token,
-                profile: auth.userData?.profile,
-                refresh_token: auth.userData?.refresh_token,
-                scope: auth.userData?.scope,
-                session_state: auth.userData?.session_state ?? "",
-                token_type: auth.userData?.token_type,
-                state: auth.userData?.state,
-                expires_in: auth.userData?.expires_in,
-                expired: auth.userData?.expired,
-                scopes: auth.userData?.scopes,
-            },
-        },
-    };
-    return lunaticDatabase.save(DATA_STATE, dataState).then(() => {
-        return dataState;
     });
 };
 
@@ -178,28 +151,33 @@ const initializeRefs = () => {
 const initDataForSurveys = (setError: (error: ErrorCodeEnum) => void) => {
     if (navigator.onLine) {
         return fetchUserSurveysInfo(setError).then(userSurveyData => {
-            let activitySurveysIds: string[] = [];
-            let userSurveyDataActivity: UserSurveys[] = [];
-            let workingTimeSurveysIds: string[] = [];
-            let userSurveyDataWorkTime: UserSurveys[] = [];
+            const activitySurveysIds: string[] = [];
+            const userSurveyDataActivity: UserSurveys[] = [];
+            const workingTimeSurveysIds: string[] = [];
+            const userSurveyDataWorkTime: UserSurveys[] = [];
+
+            // Compute the ids related to our user
             userSurveyData.forEach(surveyData => {
                 if (surveyData.questionnaireModelId === SourcesEnum.ACTIVITY_SURVEY) {
                     activitySurveysIds.push(surveyData.surveyUnitId);
                     userSurveyDataActivity.push(surveyData);
-                }
-                if (surveyData.questionnaireModelId === SourcesEnum.WORK_TIME_SURVEY) {
+                } else if (surveyData.questionnaireModelId === SourcesEnum.WORK_TIME_SURVEY) {
                     workingTimeSurveysIds.push(surveyData.surveyUnitId);
                     userSurveyDataWorkTime.push(surveyData);
                 }
+                surveyIdToInterrogationId.set(surveyData.surveyUnitId, surveyData.interrogationId);
                 userDatas.push(surveyData);
             });
+
+            // Save in global variables
             userDatasActivity = userSurveyDataActivity;
             userDatasWorkTime = userSurveyDataWorkTime;
             addArrayToSession("userDatasWorkTime", userDatasWorkTime);
             addArrayToSession("userDatasActivity", userDatasActivity);
             addArrayToSession("userDatas", userDatas);
 
-            let allSurveysIds = [...activitySurveysIds, ...workingTimeSurveysIds];
+            // Fetch the data related to our user thanks to the ids
+            const allSurveysIds = [...activitySurveysIds, ...workingTimeSurveysIds];
             const surveysIds: SurveysIds = {
                 [SurveysIdsEnum.ALL_SURVEYS_IDS]: allSurveysIds,
                 [SurveysIdsEnum.ACTIVITY_SURVEYS_IDS]: activitySurveysIds,
@@ -209,55 +187,62 @@ const initDataForSurveys = (setError: (error: ErrorCodeEnum) => void) => {
                 [SourcesEnum.ACTIVITY_SURVEY]: edtActivitySurvey,
                 [SourcesEnum.WORK_TIME_SURVEY]: edtWorkTimeSurvey,
             };
-            const innerPromises: Promise<any>[] = [
+            const innerPromises: Promise<unknown>[] = [
                 getRemoteSavedSurveysDatas(allSurveysIds, setError).then(() => {
                     return initializeSurveysDatasCache(allSurveysIds);
                 }),
                 saveSurveysIds(surveysIds),
             ];
-            const inerFetchPromises: Promise<any>[] = [
+            const innerFetchPromises: Promise<unknown>[] = [
                 saveSources(sources),
                 saveUserSurveysData({ data: userDatas }),
             ];
-            return Promise.all([...innerPromises, ...inerFetchPromises]);
+            return Promise.all([...innerPromises, ...innerFetchPromises]);
         });
     } else {
         return lunaticDatabase.get(USER_SURVEYS_DATA).then((data: LunaticData | undefined) => {
-            let userDaras = data as UserSurveysData;
-            let userSurveyData = userDaras.data;
-            let activitySurveysIds: string[] = [];
-            let userSurveyDataActivity: UserSurveys[] = [];
-            let workingTimeSurveysIds: string[] = [];
-            let userSurveyDataWorkTime: UserSurveys[] = [];
+            const userDaras = data as UserSurveysData;
+            const userSurveyData = userDaras.data;
+            const activitySurveysIds: string[] = [];
+            const userSurveyDataActivity: UserSurveys[] = [];
+            const workingTimeSurveysIds: string[] = [];
+            const userSurveyDataWorkTime: UserSurveys[] = [];
+
+            // Compute the ids related to our user
             userSurveyData.forEach(surveyData => {
                 if (surveyData.questionnaireModelId === SourcesEnum.ACTIVITY_SURVEY) {
                     activitySurveysIds.push(surveyData.surveyUnitId);
                     userSurveyDataActivity.push(surveyData);
                     if (!userDatas.find(survey => survey.surveyUnitId == surveyData.surveyUnitId))
                         userDatas.push(surveyData);
-                }
-                if (surveyData.questionnaireModelId === SourcesEnum.WORK_TIME_SURVEY) {
+                } else if (surveyData.questionnaireModelId === SourcesEnum.WORK_TIME_SURVEY) {
                     workingTimeSurveysIds.push(surveyData.surveyUnitId);
                     userSurveyDataWorkTime.push(surveyData);
                     if (!userDatas.find(survey => survey.surveyUnitId == surveyData.surveyUnitId))
                         userDatas.push(surveyData);
                 }
+                surveyIdToInterrogationId.set(surveyData.surveyUnitId, surveyData.interrogationId);
             });
+
+            // Save in global variables
             userDatasActivity = userSurveyDataActivity;
             userDatasWorkTime = userSurveyDataWorkTime;
-
             addArrayToSession("userDatasWorkTime", userDatasWorkTime);
             addArrayToSession("userDatasActivity", userDatasActivity);
             addArrayToSession("userDatas", userDatas);
-            let allSurveysIds = [...activitySurveysIds, ...workingTimeSurveysIds];
-            const innerPromisesOffline: Promise<any>[] = [initializeSurveysDatasCache(allSurveysIds)];
+
+            // Initialize the cache related to our user thanks to the ids
+            const allSurveysIds = [...activitySurveysIds, ...workingTimeSurveysIds];
+            const innerPromisesOffline: Promise<unknown>[] = [
+                initializeSurveysDatasCache(allSurveysIds),
+            ];
             return Promise.all(innerPromisesOffline);
         });
     }
 };
 
-const initializeSurveysIdsAndSources = (setError: (error: ErrorCodeEnum) => void): Promise<any> => {
-    const promises: Promise<any>[] = [];
+const initializeSurveysIdsAndSources = (setError: (error: ErrorCodeEnum) => void): Promise<unknown> => {
+    const promises: Promise<unknown>[] = [];
     return lunaticDatabase.get(SURVEYS_IDS).then(data => {
         const surveyIdsData = data as SurveysIds;
         const existSurveysIds = surveyIdsData?.[SurveysIdsEnum.ALL_SURVEYS_IDS].length > 0;
@@ -300,7 +285,7 @@ const initializeSurveysIdsAndSources = (setError: (error: ErrorCodeEnum) => void
 };
 
 const activitySurveyDemo = () => {
-    let activitySurveysIds: string[] = [];
+    const activitySurveysIds: string[] = [];
     let numInterviewer = 0;
     if (userDatas == null) userDatas = [];
     for (let i = 1; i <= Number(NUM_MAX_ACTIVITY_SURVEYS); i++) {
@@ -310,6 +295,7 @@ const activitySurveyDemo = () => {
         const userSurvey: UserSurveys = {
             interviewerId: "interviewer" + numInterviewer,
             surveyUnitId: "activitySurvey" + i,
+            interrogationId: `interrogation_${i}`,
             questionnaireModelId: SourcesEnum.ACTIVITY_SURVEY,
             campaignId: "",
             subCampaignId: "",
@@ -326,13 +312,14 @@ const activitySurveyDemo = () => {
 };
 
 const workTimeSurveyDemo = () => {
-    let workingTimeSurveysIds: string[] = [];
+    const workingTimeSurveysIds: string[] = [];
     userDatasWorkTime = [];
 
     for (let i = 1; i <= Number(NUM_MAX_WORKTIME_SURVEYS); i++) {
         const userSurvey: UserSurveys = {
             interviewerId: "interviewer" + i,
             surveyUnitId: "workTimeSurvey" + i,
+            interrogationId: `interrogation_${i}`,
             questionnaireModelId: SourcesEnum.WORK_TIME_SURVEY,
             campaignId: "",
             subCampaignId: "",
@@ -349,19 +336,19 @@ const workTimeSurveyDemo = () => {
 };
 
 const initializeSurveysIds = (innerSurveysIds: SurveysIds) => {
-    const innerPromises: Promise<any>[] = [
+    const innerPromises: Promise<unknown>[] = [
         saveSurveysIds(innerSurveysIds),
         initializeSurveysDatasCache(),
     ];
     return Promise.all(innerPromises);
 };
 
-const initializeSurveysIdsDemo = (): Promise<any> => {
+const initializeSurveysIdsDemo = (): Promise<unknown> => {
     userDatasActivity = [];
-    let activitySurveysIds = activitySurveyDemo();
-    let workingTimeSurveysIds = workTimeSurveyDemo();
+    const activitySurveysIds = activitySurveyDemo();
+    const workingTimeSurveysIds = workTimeSurveyDemo();
 
-    let allSurveysIds = [...activitySurveysIds, ...workingTimeSurveysIds];
+    const allSurveysIds = [...activitySurveysIds, ...workingTimeSurveysIds];
     const innerSurveysIds: SurveysIds = {
         [SurveysIdsEnum.ALL_SURVEYS_IDS]: allSurveysIds,
         [SurveysIdsEnum.ACTIVITY_SURVEYS_IDS]: activitySurveysIds,
@@ -372,9 +359,9 @@ const initializeSurveysIdsDemo = (): Promise<any> => {
 };
 
 const initializeHomeSurveys = (idHousehold: string) => {
-    let userDatasCopy: UserSurveys[] = [];
-    let userDatasWorkTimeCopy: UserSurveys[] = [];
-    let userDatasActivityCopy: UserSurveys[] = [];
+    let userDatasCopy: UserSurveys[];
+    const userDatasWorkTimeCopy: UserSurveys[] = [];
+    const userDatasActivityCopy: UserSurveys[] = [];
     return new Promise(resolve => {
         userDatasCopy =
             getListSurveysHousehold().find(household => household.idHousehold == idHousehold)?.surveys ??
@@ -412,7 +399,7 @@ const getSurveysIdsForHousehold = (idHousehold: string) => {
 };
 
 const setSurveysIdsReviewers = () => {
-    let allSurveysIds = getUserDatas().map(data => data.surveyUnitId);
+    const allSurveysIds = getUserDatas().map(data => data.surveyUnitId);
     const innerSurveysIds: SurveysIds = {
         [SurveysIdsEnum.ALL_SURVEYS_IDS]: allSurveysIds,
         [SurveysIdsEnum.ACTIVITY_SURVEYS_IDS]: getUserDatasActivity().map(data => data.surveyUnitId),
@@ -422,8 +409,8 @@ const setSurveysIdsReviewers = () => {
 };
 
 const initializeSurveysIdsModeReviewer = () => {
-    let activitySurveysIds: string[] = [];
-    let workingTimeSurveysIds: string[] = [];
+    const activitySurveysIds: string[] = [];
+    const workingTimeSurveysIds: string[] = [];
 
     getListSurveys().forEach(userSurvey => {
         if (userSurvey.questionnaireModelId != SourcesEnum.WORK_TIME_SURVEY) {
@@ -433,7 +420,7 @@ const initializeSurveysIdsModeReviewer = () => {
         }
     });
 
-    let allSurveysIds = [...activitySurveysIds, ...workingTimeSurveysIds];
+    const allSurveysIds = [...activitySurveysIds, ...workingTimeSurveysIds];
     const innerSurveysIds: SurveysIds = {
         [SurveysIdsEnum.ALL_SURVEYS_IDS]: allSurveysIds,
         [SurveysIdsEnum.ACTIVITY_SURVEYS_IDS]: activitySurveysIds,
@@ -445,9 +432,9 @@ const initializeSurveysIdsModeReviewer = () => {
 const refreshSurveyData = (
     setError: (error: ErrorCodeEnum) => void,
     specifiquesSurveysIds?: string[],
-): Promise<any> => {
+): Promise<unknown> => {
     initData = false;
-    const promisesToWait: Promise<any>[] = [];
+    const promisesToWait: Promise<unknown>[] = [];
     promisesToWait.push(
         getRemoteSavedSurveysDatas(
             specifiquesSurveysIds ?? surveysIds[SurveysIdsEnum.ALL_SURVEYS_IDS],
@@ -459,7 +446,7 @@ const refreshSurveyData = (
     return Promise.all(promisesToWait);
 };
 
-const refreshSurvey = (idSurvey: string, setError: (error: ErrorCodeEnum) => void): Promise<any> => {
+const refreshSurvey = (idSurvey: string, setError: (error: ErrorCodeEnum) => void): Promise<unknown> => {
     initData = false;
     return getRemoteSavedSurveysDatas([idSurvey], setError).then(() => {
         return initializeSurveysDatasCache([idSurvey]);
@@ -468,7 +455,7 @@ const refreshSurvey = (idSurvey: string, setError: (error: ErrorCodeEnum) => voi
 
 const initializeSurveysIdsDataModeReviewer = (
     setError: (error: ErrorCodeEnum) => void,
-): Promise<any> => {
+): Promise<unknown> => {
     initializeSurveysIdsModeReviewer();
     return initializeSurveysIds(surveysIds).then(() => {
         if (!initData && navigator.onLine) {
@@ -482,9 +469,10 @@ const initializeSurveysIdsDataModeReviewer = (
 /**
  * Create a data object from fetched survey data
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const initializeData = (remoteSurveyData: any, idSurvey: string) => {
     const regexp = new RegExp(import.meta.env.VITE_HOUSE_REFERENCE_REGULAR_EXPRESSION || "");
-    let surveyData: LunaticData = {
+    const surveyData: LunaticData = {
         COLLECTED: {},
         CALCULATED: {},
         EXTERNAL: {},
@@ -508,82 +496,89 @@ const initializeData = (remoteSurveyData: any, idSurvey: string) => {
 const getRemoteSavedSurveyData = (
     surveyId: string,
     setError: (error: ErrorCodeEnum) => void,
-): Promise<any> => {
+): Promise<unknown> => {
     if (!navigator.onLine) {
         return Promise.reject(new Error("Offline"));
     }
 
-    const getSurveyDataFunction = isReviewer() ? requestGetDataReviewer : remoteGetSurveyData;
-    const getSurveyStateDataFunction = remoteGetSurveyStateData;
+    const getSurveyDataFunction = isReviewer()
+        ? requestGetDataReviewer
+        : (_: string, interrogationId: string, setError: (error: ErrorCodeEnum) => void) =>
+              remoteGetSurveyData(interrogationId, setError);
 
     //TODO: Refactor dirty code
-    return getSurveyDataFunction(surveyId, setError)
-        .then((remoteSurveyData: any) => {
-            const surveyData = initializeData(remoteSurveyData, surveyId);
-            return lunaticDatabase.get(surveyId).then(localSurveyData => {
-                if (shouldInitData(remoteSurveyData, localSurveyData)) {
-                    const stateData = getLocalSurveyStateData(surveyData);
-                    return saveInDatabase(surveyId, { ...surveyData, stateData });
-                } else {
-                    if (shouldPushLocalData(remoteSurveyData, localSurveyData)) {
-                        return saveData(surveyId, localSurveyData as any, {});
-                    } else if (shouldSaveRemoteData(remoteSurveyData, localSurveyData)) {
-                        // TEMP: WeeklyPlanner stuff (to be removed)
-                        if (remoteSurveyData.COLLECTED && "WEEKTYPE" in remoteSurveyData.COLLECTED) {
-                            const weeklyPlannerData = createDataWeeklyPlanner(remoteSurveyData);
-                            const WeeklyPlannerVariable: MultiCollected = {
-                                COLLECTED: weeklyPlannerData,
-                                EDITED: [],
-                                FORCED: null,
-                                INPUTED: null,
-                                PREVIOUS: null,
-                            };
-                            remoteSurveyData.COLLECTED["WEEKLYPLANNER"] = WeeklyPlannerVariable;
-                        }
-                        return getSurveyStateDataFunction(surveyId, setError)
-                            .then(stateData => {
-                                return saveInDatabase(surveyId, { ...remoteSurveyData, stateData });
-                            })
-                            .catch(error => {
-                                console.error(
-                                    `Error in getSurveyStateDataFunction or saveInDatabase for surveyId ${surveyId}:`,
-                                    error,
-                                );
-                                // Handle the error and return a fallback value
-                                return saveInDatabase(surveyId, {
-                                    ...remoteSurveyData,
-                                    stateData: null,
+    const interrogationId = surveyIdToInterrogationId.get(surveyId)!;
+    return (
+        getSurveyDataFunction(surveyId, interrogationId, setError)
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            .then((remoteSurveyData: any) => {
+                const surveyData = initializeData(remoteSurveyData, surveyId);
+                return lunaticDatabase.get(surveyId).then(localSurveyData => {
+                    if (shouldInitData(remoteSurveyData, localSurveyData)) {
+                        const stateData = getLocalSurveyStateData(surveyData);
+                        return saveInDatabase(surveyId, { ...surveyData, stateData });
+                    } else {
+                        if (shouldPushLocalData(remoteSurveyData, localSurveyData)) {
+                            return saveData(surveyId, localSurveyData!, {});
+                        } else if (shouldSaveRemoteData(remoteSurveyData, localSurveyData)) {
+                            // TEMP: WeeklyPlanner stuff (to be removed)
+                            if (remoteSurveyData.COLLECTED && "WEEKTYPE" in remoteSurveyData.COLLECTED) {
+                                const weeklyPlannerData = createDataWeeklyPlanner(remoteSurveyData);
+                                const WeeklyPlannerVariable: MultiCollected = {
+                                    COLLECTED: weeklyPlannerData,
+                                    EDITED: [],
+                                    FORCED: null,
+                                    INPUTED: null,
+                                    PREVIOUS: null,
+                                };
+                                remoteSurveyData.COLLECTED["WEEKLYPLANNER"] = WeeklyPlannerVariable;
+                            }
+                            return remoteGetSurveyStateData(interrogationId, setError)
+                                .then(stateData => {
+                                    return saveInDatabase(surveyId, { ...remoteSurveyData, stateData });
+                                })
+                                .catch(error => {
+                                    console.error(
+                                        `Error in getSurveyStateDataFunction or saveInDatabase for surveyId ${surveyId}:`,
+                                        error,
+                                    );
+                                    // Handle the error and return a fallback value
+                                    return saveInDatabase(surveyId, {
+                                        ...remoteSurveyData,
+                                        stateData: null,
+                                    });
                                 });
-                            });
+                        }
                     }
-                }
-            });
-        })
-        .catch(err => {
-            console.error(err);
-            setError(err);
-        });
+                });
+            })
+            .catch(err => {
+                console.error(err);
+                setError(err);
+            })
+    );
 };
 
 const getRemoteSavedSurveysDatas = (
     surveysIds: string[],
     setError: (error: ErrorCodeEnum) => void,
-): Promise<any[]> => {
-    const promises = surveysIds.map(surveyId =>
+): Promise<unknown[]> => {
+    const promises = surveysIds.map(surveyId => {
         getRemoteSavedSurveyData(surveyId, setError)
             .then(result => {
                 return result;
             })
             .catch(() => {
                 return undefined;
-            }),
-    );
+            });
+    });
 
     return Promise.all(promises).then(results => {
         return results.filter(result => result !== undefined);
     });
 };
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const shouldSaveRemoteData = (remoteSurveyData: any, localSurveyData: any): boolean => {
     const lastRemoteSaveDate =
         remoteSurveyData.lastRemoteSaveDate ?? remoteSurveyData.data?.lastRemoteSaveDate ?? 1;
@@ -602,6 +597,7 @@ const shouldSaveRemoteData = (remoteSurveyData: any, localSurveyData: any): bool
 /**
  * Should local data be sent to the server
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const shouldPushLocalData = (remoteGetSurveyData: any, localSurveyData: any): boolean => {
     return (
         localSurveyData?.lastLocalSaveDate &&
@@ -613,6 +609,7 @@ const shouldPushLocalData = (remoteGetSurveyData: any, localSurveyData: any): bo
 /**
  * Detect if collected data is empty
  */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const shouldInitData = (remoteSurveyData: any, localSurveyData: any): boolean => {
     if (!localSurveyData) {
         if (remoteSurveyData && typeof remoteSurveyData === "object") {
@@ -624,8 +621,8 @@ const shouldInitData = (remoteSurveyData: any, localSurveyData: any): boolean =>
     return false;
 };
 
-const initializeSurveysDatasCache = (idSurveys?: string[]): Promise<any> => {
-    const promises: Promise<any>[] = [];
+const initializeSurveysDatasCache = (idSurveys?: string[]): Promise<unknown> => {
+    const promises: Promise<unknown>[] = [];
     const idSurveysToInit = idSurveys ?? surveysIds[SurveysIdsEnum.ALL_SURVEYS_IDS];
     return lunaticDatabase.get(SURVEYS_IDS).then(data => {
         surveysIds = data as SurveysIds;
@@ -685,13 +682,13 @@ const initializeListSurveys = (setError: (error: ErrorCodeEnum) => void) => {
             .catch(err => {
                 console.error(err);
                 return lunaticDatabase.get(USER_SURVEYS_DATA).then((data: LunaticData | undefined) => {
-                    let datas = data as UserSurveysData;
+                    const datas = data as UserSurveysData;
                     return datas.data;
                 });
             });
     } else {
         return lunaticDatabase.get(USER_SURVEYS_DATA).then((data: LunaticData | undefined) => {
-            let datas = data as UserSurveysData;
+            const datas = data as UserSurveysData;
             surveysData = datas.data;
             addArrayToSession("surveysData", surveysData);
             datas.data.forEach((surveyData: UserSurveys) => {
@@ -712,7 +709,8 @@ const getListSurveys = () => {
     return surveysData ?? getArrayFromSession("surveysData");
 };
 
-const getSurveyDataHousehold = (surveys: UserSurveys[]) => {
+/** Compute the first date from the survey in a DD/MM/YYYY format */
+const getSurveyDataHousehold = (surveys: UserSurveys[]): string | undefined => {
     const activitiesSurveys = surveys
         .filter(survey => survey.questionnaireModelId == SourcesEnum.ACTIVITY_SURVEY)
         .map(survey => survey.surveyUnitId);
@@ -733,12 +731,12 @@ const getSurveyDataHousehold = (surveys: UserSurveys[]) => {
 
 const getListSurveysHousehold = (): Household[] => {
     const listSurveys = getListSurveys();
-    let grouped = groupBy(listSurveys, surveyData => {
+    const grouped = groupBy(listSurveys, surveyData => {
         const length = surveyData.surveyUnitId.length - 1;
         const group = surveyData.surveyUnitId.substring(0, length);
         return group;
     });
-    let mapped = Object.entries(grouped)
+    const mapped = Object.entries(grouped)
         .map(([key, value]) => {
             return {
                 idHousehold: key,
@@ -751,6 +749,7 @@ const getListSurveysHousehold = (): Household[] => {
             };
         })
         .sort(
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
             (houseHoldData1: any, houseHoldData2: any) =>
                 Number(houseHoldData1.idHousehold) - Number(houseHoldData2.idHousehold),
         );
@@ -762,11 +761,7 @@ const getDatas = (): Map<string, LunaticData> => {
 };
 
 const getData = (idSurvey: string): LunaticData => {
-    const modifyCollected = modifyIndividualCollected(idSurvey);
-    // const emptyData = getDataCache(idSurvey) ?? createDataEmpty(idSurvey ?? "");
-    // const data = modifyCollected || emptyData;
-    // return data;
-    return modifyCollected;
+    return modifyIndividualCollected(idSurvey);
 };
 
 const getDataCache = (idSurvey: string) => {
@@ -794,7 +789,7 @@ const modifyIndividualCollected = (idSurvey: string) => {
     }
     if (getModePersistence(dataSurv) != ModePersistenceEnum.EDITED) {
         const dataOfSurvey = dataSurv?.COLLECTED;
-        for (let prop in FieldNameEnum as any) {
+        for (const prop in FieldNameEnum) {
             const data = dataOfSurvey?.[prop];
             if (
                 data?.EDITED &&
@@ -879,9 +874,9 @@ const updateLocked = (isReviewerMode: boolean, data: LunaticData) => {
 };
 
 const getDataUpdatedOffline = () => {
-    let surveysToUpdated = new Map<string, LunaticData>();
+    const surveysToUpdated = new Map<string, LunaticData>();
     surveysIds[SurveysIdsEnum.ALL_SURVEYS_IDS].forEach(idSurvey => {
-        let data = getDataCache(idSurvey);
+        const data = getDataCache(idSurvey);
         //state data -> last data recuperée from stateData
         //lastRemoteSaveDate -> a pouvoir supprimer (change lastRemoteSaveDate to stateData.date)
         if (
@@ -895,7 +890,7 @@ const getDataUpdatedOffline = () => {
 };
 
 const saveDatas = () => {
-    const promisesToWait: Promise<any>[] = [];
+    const promisesToWait: Promise<unknown>[] = [];
     getDataUpdatedOffline().forEach((value, key) => {
         promisesToWait.push(saveData(key, value, { localSaveOnly: false, forceUpdate: true }));
     });
@@ -961,9 +956,10 @@ async function saveData(
                 data: data,
             };
             data.lastRemoteSaveDate = stateData.date;
+            const interrogationId = surveyIdToInterrogationId.get(idSurvey)!;
             if (isReviewerMode) {
                 // We're in async
-                return remotePutSurveyDataReviewer(idSurvey, stateData, data).then(() => {
+                return remotePutSurveyDataReviewer(interrogationId, stateData, data).then(() => {
                     stateData.date = Math.max(stateData.date, data.lastLocalSaveDate ?? 0);
                     data.stateData = stateData;
                     data.lastRemoteSaveDate = stateData.date;
@@ -983,7 +979,7 @@ async function saveData(
                     return saveInDatabase(idSurvey, data);
                 });
             } else {
-                return remotePutSurveyData(idSurvey, surveyData, surveyType).then(() => {
+                return remotePutSurveyData(interrogationId, surveyData, surveyType).then(() => {
                     data.stateData = stateData;
                     const revertedTranformedData = revertTransformedArray(data.COLLECTED);
                     data.COLLECTED = revertedTranformedData;
@@ -1030,7 +1026,7 @@ const saveDataLocally = (
  * Save the new data in the database and keep the previous data in "oldDatas" variable
  */
 const saveInDatabase = (idSurvey: string, data: LunaticData) => {
-    let oldDataSurvey = datas.get(idSurvey) ?? {};
+    const oldDataSurvey = datas.get(idSurvey) ?? {};
     oldDatas.set(idSurvey, oldDataSurvey);
     setDataCache(idSurvey, data);
     return lunaticDatabase.save(idSurvey, data).then(() => {
@@ -1070,7 +1066,7 @@ const saveUserSurveysData = (data: UserSurveysData): Promise<UserSurveys[]> => {
               return data.data;
           })
         : lunaticDatabase.get(USER_SURVEYS_DATA).then(userDatas => {
-              let userDatasLocal = userDatas as UserSurveysData;
+              const userDatasLocal = userDatas as UserSurveysData;
               return userDatasLocal?.data;
           });
 };
@@ -1143,7 +1139,7 @@ const haveVariableNotFilled = (
                 filled = false;
             } else if (Array.isArray(value)) {
                 const arrayWeeklyPlanner = value as { [key: string]: string }[];
-                filled = arrayWeeklyPlanner.find((val: any) => val != null) == null;
+                filled = arrayWeeklyPlanner.find((val: unknown) => val != null) == null;
             } else filled = true;
         }
     });
@@ -1174,7 +1170,7 @@ const getValue = (idSurvey: string, variableName: FieldNameEnum, iteration?: num
         if (modePersistenceEdited && valueEdited?.[iteration] != null) value = valueEdited;
         return Array.isArray(value) ? value[iteration] : null;
     } else {
-        let value = modePersistenceEdited && valueEdited != null ? valueEdited : valueCollected;
+        const value = modePersistenceEdited && valueEdited != null ? valueEdited : valueCollected;
         return value;
     }
 };
@@ -1185,7 +1181,7 @@ const setValue = (
     value: string | boolean | null,
     iteration?: number,
 ): LunaticData => {
-    let dataAct = getDataCache(idSurvey) ?? {};
+    const dataAct = getDataCache(idSurvey) ?? {};
     if (dataAct == null) {
         lunaticDatabase.get(idSurvey).then(data => {
             getDataModePersist(idSurvey, data ?? {}, variableName, value, iteration);
@@ -1276,8 +1272,12 @@ const getIdSurveyWorkTime = (interviewer: string) => {
     return getUserDatasWorkTime().filter(data => data.interviewerId == interviewer)[0]?.surveyUnitId;
 };
 
-const createTabData = (idSurvey: string, t: any, isActivitySurvey: boolean) => {
-    let tabData: TabData = {
+const createTabData = (
+    idSurvey: string,
+    t: TFunction<"translation", undefined>,
+    isActivitySurvey: boolean,
+) => {
+    const tabData: TabData = {
         idSurvey: idSurvey,
         surveyDateLabel: getPrintedSurveyDate(
             idSurvey,
@@ -1290,8 +1290,8 @@ const createTabData = (idSurvey: string, t: any, isActivitySurvey: boolean) => {
     return tabData;
 };
 
-const getTabsDataReviewer = (t: any) => {
-    let tabsData: TabData[] = [];
+const getTabsDataReviewer = (t: TFunction<"translation", undefined>) => {
+    const tabsData: TabData[] = [];
 
     const interviewers = getUserDatasActivity().map(data => data.interviewerId);
     const interviewersUniques = interviewers.filter(
@@ -1299,7 +1299,7 @@ const getTabsDataReviewer = (t: any) => {
     );
 
     interviewersUniques.forEach(interviewer => {
-        let tabData1 = createTabData(getIdSurveyActivity(interviewer, 0), t, true);
+        const tabData1 = createTabData(getIdSurveyActivity(interviewer, 0), t, true);
         tabsData.push(tabData1);
         const tabData2 = createTabData(getIdSurveyActivity(interviewer, 1), t, true);
         tabsData.push(tabData2);
@@ -1311,8 +1311,8 @@ const getTabsDataReviewer = (t: any) => {
     return tabsData;
 };
 
-const getTabsDataInterviewer = (t: any) => {
-    let tabsData: TabData[] = [];
+const getTabsDataInterviewer = (t: TFunction<"translation", undefined>) => {
+    const tabsData: TabData[] = [];
 
     const dataOrdered = getOrderedSurveys(
         surveysIds[SurveysIdsEnum.ACTIVITY_SURVEYS_IDS],
@@ -1327,7 +1327,7 @@ const getTabsDataInterviewer = (t: any) => {
     return tabsData;
 };
 
-const getTabsData = (t: any): TabData[] => {
+const getTabsData = (t: TFunction<"translation", undefined>): TabData[] => {
     if (isDemoMode()) {
         return getTabsDataReviewer(t);
     }
@@ -1430,6 +1430,7 @@ const createNameSurveyMap = (idSurveys: string[]) => {
                 questionnaireModelId: isActivity
                     ? SourcesEnum.ACTIVITY_SURVEY
                     : SourcesEnum.WORK_TIME_SURVEY,
+                interrogationId: surveyIdToInterrogationId.get(idSurvey) || "",
                 id: 0,
                 campaignId: "",
                 subCampaignId: "",
@@ -1460,7 +1461,7 @@ const nameSurveyGroupMap = () => {
         surveysIds[SurveysIdsEnum.ACTIVITY_SURVEYS_IDS],
         surveysIds[SurveysIdsEnum.WORK_TIME_SURVEYS_IDS],
     );
-    let grouped = groupBy(listSurveysAct, nameSurveyData => nameSurveyData.num);
+    const grouped = groupBy(listSurveysAct, nameSurveyData => nameSurveyData.num);
     return grouped;
 };
 
@@ -1516,6 +1517,7 @@ const arrayOfSurveysPersonDemo = (interviewer: string, index: number): Person[] 
             data: {
                 questionnaireModelId: SourcesEnum.ACTIVITY_SURVEY,
                 surveyUnitId: getIdSurveyActivity(interviewer, 0),
+                interrogationId: "",
                 interviewerId: interviewer,
                 campaignId: "",
                 subCampaignId: "",
@@ -1527,6 +1529,7 @@ const arrayOfSurveysPersonDemo = (interviewer: string, index: number): Person[] 
             data: {
                 questionnaireModelId: SourcesEnum.ACTIVITY_SURVEY,
                 surveyUnitId: getIdSurveyActivity(interviewer, 1),
+                interrogationId: "",
                 interviewerId: interviewer,
                 campaignId: "",
                 subCampaignId: "",
@@ -1538,6 +1541,7 @@ const arrayOfSurveysPersonDemo = (interviewer: string, index: number): Person[] 
             data: {
                 questionnaireModelId: SourcesEnum.WORK_TIME_SURVEY,
                 surveyUnitId: getIdSurveyWorkTime(interviewer),
+                interrogationId: "",
                 interviewerId: interviewer,
                 campaignId: "",
                 subCampaignId: "",
@@ -1616,7 +1620,7 @@ const existVariableEdited = (idSurvey?: string, data?: LunaticData) => {
     const dataSurv = data ?? getDataCache(idSurvey ?? "");
     const dataOfSurvey = dataSurv?.COLLECTED;
 
-    for (let prop in FieldNameEnum as any) {
+    for (const prop in FieldNameEnum) {
         if (prop == FieldNameEnum.FIRSTNAME) continue;
         const surveyData = dataOfSurvey?.[prop];
         const ifArrayInputed =
@@ -1634,24 +1638,9 @@ const existVariableEdited = (idSurvey?: string, data?: LunaticData) => {
     return false;
 };
 
-// @ts-ignore
-const getModePersistence = (data: LunaticData | undefined): ModePersistenceEnum => {
+const getModePersistence = (_: LunaticData | undefined): ModePersistenceEnum => {
     // We don't want to use EDITED anymore, to minimize changes we will simulate COLLECTED for everything
     return ModePersistenceEnum.COLLECTED;
-    /*
-    const isReviewerMode = isReviewer();
-    const isLocked = data?.COLLECTED?.[FieldNameEnum.ISLOCKED]?.COLLECTED as boolean;
-    return isReviewerMode || isLocked || existVariableEdited(undefined, data)
-        ? ModePersistenceEnum.EDITED
-        : ModePersistenceEnum.COLLECTED;
-     */
-};
-
-const getValueWithData = (
-    data: LunaticData | undefined,
-    variableName: string,
-): string | boolean | string[] | boolean[] | null[] | { [key: string]: string }[] | null | undefined => {
-    return data?.COLLECTED?.[variableName]?.COLLECTED;
 };
 
 const getValueOfData = (
@@ -1679,8 +1668,8 @@ const getSurveysAct = () => {
     if (getUserRights() === EdtUserRightsEnum.REVIEWER && !isDemo) {
         surveys = userDatasMap();
     } else if (getUserRights() === EdtUserRightsEnum.REVIEWER) {
-        let interviewers = getUserDatasActivity().map(data => data.interviewerId);
-        let interviewersUniques = interviewers.filter(
+        const interviewers = getUserDatasActivity().map(data => data.interviewerId);
+        const interviewersUniques = interviewers.filter(
             (value, index, self) => self.indexOf(value) === index,
         );
         interviewersUniques.forEach((interviewer, index) => {
@@ -1733,7 +1722,7 @@ const validateAllGroup = (
 
 const initSurveyData = (surveyId: string): LunaticData => {
     const regexp = new RegExp(import.meta.env.VITE_HOUSE_REFERENCE_REGULAR_EXPRESSION || "");
-    let surveyData: LunaticData = {
+    const surveyData: LunaticData = {
         COLLECTED: {},
         CALCULATED: {},
         EXTERNAL: {},
@@ -1753,20 +1742,15 @@ const initSurveyData = (surveyId: string): LunaticData => {
 export {
     addToAutocompleteActivityReferentiel,
     arrayOfSurveysPersonDemo,
-    createDataEmpty,
-    createNameSurveyMap,
     existVariableEdited,
     getComponentId,
     getComponentsOfVariable,
     getCurrentPage,
     getData,
-    getDataEmpty,
-    getDataUpdatedOffline,
     getDatas,
     getFirstName,
     getFullFrenchDate,
     getIdSurveyActivity,
-    getIdSurveyWorkTime,
     getListSurveys,
     getListSurveysHousehold,
     getModePersistence,
@@ -1783,13 +1767,10 @@ export {
     getTabsData,
     getUserDatas,
     getUserDatasActivity,
-    getUserDatasWorkTime,
     getValue,
     getValueOfData,
-    getValueWithData,
     getVarBooleanModepersistance,
     getVariable,
-    initPropsAuth,
     initStateData,
     initSurveyData,
     initializeDatas,
@@ -1798,9 +1779,7 @@ export {
     initializeSurveysDatasCache,
     initializeSurveysIdsDataModeReviewer,
     initializeSurveysIdsDemo,
-    initializeSurveysIdsModeReviewer,
     nameSurveyGroupMap,
-    nameSurveyMap,
     navToPlanner,
     refreshSurvey,
     refreshSurveyData,

--- a/src/service/survey-service.ts
+++ b/src/service/survey-service.ts
@@ -696,6 +696,7 @@ const initializeListSurveys = (setError: (error: ErrorCodeEnum) => void) => {
                 surveysData = data;
                 addArrayToSession("surveysData", surveysData);
                 data.forEach((surveyData: UserSurveys) => {
+                    surveyIdToInterrogationId.set(surveyData.surveyUnitId, surveyData.interrogationId);
                     if (!userDatas?.find(user => user.surveyUnitId == surveyData.surveyUnitId)) {
                         if (userDatas == null) userDatas = [];
                         if (surveyData.questionnaireModelId === SourcesEnum.ACTIVITY_SURVEY) {


### PR DESCRIPTION
Platine back office (Queen API Code) is moving its endpoints from 
- /api/survey-unit/{id}/state-data
- /api/survey-unit/{id}/data
to
- /api/interrogations/{id}/data
- /api/interrogations/{id}/state-data

Reminder : the ids are collected from the edt api which database will be updated to serve interrogation id instead of survey-unit id